### PR TITLE
#48 Searchable pluggable interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'bootstrap',                '~> 4.0.0.alpha5'
 #=== FEATUES ====================================
 gem 'devise'
 gem 'stripe'
+gem 'pg_search'
 gem 'interactor-rails',                  '~> 2.0'
 gem 'omniauth-facebook'
 gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,10 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     pg (0.19.0)
+    pg_search (1.0.6)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+      arel
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -417,6 +421,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-github
   pg (~> 0.18)
+  pg_search
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.1)

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -31,7 +31,7 @@ module Admin
     end
 
     def members
-      @members ||= User.order(:id)
+      @members ||= params[:query] ? User.by_email(params[:query]) : User.order(:id)
     end
 
     def users_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  include ::Searchable
+
   extend FriendlyId
   include Publishable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include ::Searchable
+
   extend FriendlyId
   friendly_id :full_name, use: :slugged
 

--- a/app/modules/searchable.rb
+++ b/app/modules/searchable.rb
@@ -1,0 +1,17 @@
+module Searchable
+  class << self
+    def included(base)
+      base.include(search_module)
+
+      resolver.call(target: base)
+    end
+
+    def search_module
+      PgSearch
+    end
+
+    def resolver
+      ::Searchable::Resolver
+    end
+  end
+end

--- a/app/modules/searchable/configurable.rb
+++ b/app/modules/searchable/configurable.rb
@@ -1,0 +1,19 @@
+module Searchable
+  module Configurable
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def define_searchable(&block)
+        return unless block_given?
+
+        definitions << block
+      end
+
+      def definitions
+        @definitions ||= []
+      end
+    end
+  end
+end

--- a/app/modules/searchable/configuration/event.rb
+++ b/app/modules/searchable/configuration/event.rb
@@ -1,0 +1,13 @@
+module Searchable
+  module Configuration
+    module Event
+      include Configurable
+
+      define_searchable do
+        %i(title agenda description).each do |attribute|
+          pg_search_scope "by_#{attribute}", against: attribute
+        end
+      end
+    end
+  end
+end

--- a/app/modules/searchable/configuration/user.rb
+++ b/app/modules/searchable/configuration/user.rb
@@ -1,0 +1,13 @@
+module Searchable
+  module Configuration
+    module User
+      include Configurable
+
+      define_searchable do
+        pg_search_scope :by_email, against: :email, using: { tsearch: { prefix: true } }
+
+        multisearchable            against: %i(first_name last_name email)
+      end
+    end
+  end
+end

--- a/app/modules/searchable/mapping.rb
+++ b/app/modules/searchable/mapping.rb
@@ -1,0 +1,8 @@
+module Searchable
+  module Mapping
+    MAPPING = {
+      user:  Configuration::User,
+      event: Configuration::Event
+    }
+  end
+end

--- a/app/modules/searchable/resolver.rb
+++ b/app/modules/searchable/resolver.rb
@@ -1,0 +1,33 @@
+module Searchable
+  class Resolver
+    include Mapping
+
+    def self.call(params)
+      new(params).perform
+    end
+
+    def initialize(params)
+      @target = params[:target]
+    end
+
+    def perform
+      Array(definitions).each { |definition| apply!(definition) }
+    end
+
+    private
+
+    attr_reader :target
+
+    delegate :model_name,  to: :target
+    delegate :i18n_key,    to: :model_name, prefix: true
+    delegate :definitions, to: :configuration, allow_nil: true
+
+    def apply!(definition)
+      target.class_exec(&definition)
+    end
+
+    def configuration
+      @configuration ||= MAPPING[model_name_i18n_key]
+    end
+  end
+end

--- a/app/views/admin/members/index.slim
+++ b/app/views/admin/members/index.slim
@@ -1,6 +1,7 @@
 h2 = t 'members.plural'
 
 = admin_new_member_link
+= render 'admin/shared/search_bar', url: admin_members_path
 
 .table-responsive
   table.table

--- a/app/views/admin/shared/_search_bar.slim
+++ b/app/views/admin/shared/_search_bar.slim
@@ -1,0 +1,3 @@
+= form_tag url, method: :get do
+  = text_field_tag :query, params[:query], class: 'form-control mt-1'
+  = submit_tag 'Search', name: nil, class: 'btn btn-default mt-1'

--- a/db/migrate/20170112150905_create_pg_search_documents.rb
+++ b/db/migrate/20170112150905_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration
+  def self.up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, :polymorphic => true, :index => true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def self.down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20170112175932) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +83,15 @@ ActiveRecord::Schema.define(version: 20170112175932) do
     t.string  "provider"
     t.integer "user_id"
     t.index ["user_id"], name: "index_identities_on_user_id", using: :btree
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text     "content"
+    t.string   "searchable_type"
+    t.integer  "searchable_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id", using: :btree
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/lib/tasks/searchable/reindex.rake
+++ b/lib/tasks/searchable/reindex.rake
@@ -1,0 +1,9 @@
+namespace :searchable do
+  desc 'reindex models that include searchable module for multisearch purposes'
+  task reindex: :environment do
+    models = ApplicationRecord.descendants.select { |m| m.respond_to? :pg_search_multisearchable_options }
+    models.each { |model_name| PgSearch::Multisearch.rebuild(model_name) }
+
+    p "Finished reindexing total of #{models.count} models"
+  end
+end

--- a/spec/modules/searchable/configurable_spec.rb
+++ b/spec/modules/searchable/configurable_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe ::Searchable::Configurable do
+  let(:subject) { Class.new }
+  let(:definition) { Proc.new {} }
+
+  describe '.included' do
+    it 'extends target class' do
+      expect(subject).to receive(:extend).with(described_class::ClassMethods)
+      subject.include(described_class)
+    end
+  end
+
+  before do
+    subject.include(described_class)
+  end
+
+  it 'makes .define_searchable available' do
+    expect(subject).to respond_to :define_searchable
+  end
+
+  it 'makes .definitions available' do
+    expect(subject).to respond_to :definitions
+  end
+
+  describe '.definitions' do
+    it 'returns an array' do
+      expect(subject.definitions).to be_an_instance_of Array
+    end
+  end
+
+  describe '.define_searchable' do
+    before { subject.define_searchable(&definition) }
+
+    it 'adds a definition to an array' do
+      expect(subject.definitions).to eq [definition]
+    end
+  end
+end

--- a/spec/modules/searchable/configuration/event_spec.rb
+++ b/spec/modules/searchable/configuration/event_spec.rb
@@ -1,0 +1,5 @@
+require 'modules/searchable/configuration/shared_group'
+
+RSpec.describe ::Searchable::Configuration::Event do
+  it_behaves_like 'Configurable'
+end

--- a/spec/modules/searchable/configuration/shared_group.rb
+++ b/spec/modules/searchable/configuration/shared_group.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples 'Configurable' do |action_hook|
+  let(:configurable_module) { Searchable::Configurable }
+
+  it 'responds to configurable methods' do
+    expect(described_class).to respond_to :definitions
+    expect(described_class).to respond_to :define_searchable
+  end
+end

--- a/spec/modules/searchable/configuration/user_spec.rb
+++ b/spec/modules/searchable/configuration/user_spec.rb
@@ -1,0 +1,5 @@
+require 'modules/searchable/configuration/shared_group'
+
+RSpec.describe ::Searchable::Configuration::User do
+  it_behaves_like 'Configurable'
+end

--- a/spec/modules/searchable/mapping_spec.rb
+++ b/spec/modules/searchable/mapping_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe ::Searchable::Mapping do
+  it 'contains configuration mapping' do
+    expect(described_class::MAPPING).not_to be nil
+  end
+end
+

--- a/spec/modules/searchable/resolver_spec.rb
+++ b/spec/modules/searchable/resolver_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Searchable::Resolver do
+  let(:target)     { User }
+  let(:subject)    { described_class.new(target: target) }
+  let(:config)     { double() }
+  let(:definition) { Proc.new { pg_search_scope :by_name, against: [:first_name] } }
+
+  before do
+    allow(subject).to receive(:configuration) { config }
+    allow(config).to receive(:definitions) { [definition] }
+    target.include(PgSearch)
+  end
+
+  describe '#perform' do
+    it 'applies search definitions to the target' do
+      subject.perform
+      expect(target).to respond_to :by_name
+    end
+  end
+end

--- a/spec/modules/searchable_spec.rb
+++ b/spec/modules/searchable_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe ::Searchable do
+  let(:subject)       { Class.new }
+  let(:resolver)      { ::Searchable::Resolver }
+  let(:search_module) { PgSearch }
+
+  describe '.included' do
+    it 'calls resolver with correct arguments' do
+      expect(resolver).to receive(:call).with(target: subject)
+      subject.include(described_class)
+    end
+
+    it 'responds to search module methods' do
+      allow(resolver).to receive(:call) { true }
+      subject.include(described_class)
+
+      expect(subject).to respond_to :pg_search_scope
+      expect(subject).to respond_to :multisearchable
+    end
+  end
+
+  describe '.search_module' do
+    it 'returns correct class' do
+      expect(described_class.search_module).to eq search_module
+    end
+  end
+
+  describe '.resolver' do
+    it 'returns correct class' do
+      expect(described_class.resolver).to eq resolver
+    end
+  end
+end


### PR DESCRIPTION
Sup guys :v: 

Basically a simple full-text search implementation using a modular approach to separate large search scopes from models.

All you have to do is 
1. `include ::Searchable` 
2. Add a mapping to `Searchable::Mapping` module
3. Define scopes of your choice in configuration modules 

There's also a rake task to reindex the models that include `::Searchable` module for multisearch which is required once the configuration changes per say 

 :vulcan_salute: 

