### PR TITLE
Fix unverified_attendee email sent to verified users

### DIFF
--- a/app/services/visit_request/create.rb
+++ b/app/services/visit_request/create.rb
@@ -7,18 +7,14 @@ class VisitRequest
 
     def call
       return visit_request.approved! if user.verified? && policy.has_free_slot_for?(user)
-
-      unless user.verified? && policy.has_free_slot_for?(user)
-        visit_request.pending!
-        VisitRequestMailer.unverified_attendee(visit_request.id).deliver_later
-      end
-
+      VisitRequestMailer.unverified_attendee(visit_request.id).deliver_later unless user.verified?
+      visit_request.pending!
       visit_request.waiting_list! unless policy.has_free_slot_for?(user)
     end
 
     private
 
-    attr_reader :user, :event, :policy
+    attr_reader :user, :event
 
     def visit_request
       @visit_request ||= VisitRequest.find_or_initialize_by(

--- a/spec/services/visit_request/create_spec.rb
+++ b/spec/services/visit_request/create_spec.rb
@@ -21,9 +21,12 @@ describe VisitRequest::Create do
         it { expect(event.visit_requests.last).to_not be_waiting_list }
       end
 
-      context 'event not has free slots for verified users' do
+      context 'event has no free slots for verified users' do
         before do
           allow_any_instance_of(Event::SlotsPolicy).to receive(:has_free_slot_for?).with(user) { false }
+
+          expect(VisitRequestMailer).not_to receive(:unverified_attendee)
+
           subject.call
         end
 
@@ -52,7 +55,7 @@ describe VisitRequest::Create do
         it { expect(event.visit_requests.last).to_not be_waiting_list }
       end
 
-      context 'event not has free slots for newbies' do
+      context 'event has no free slots for newbies' do
         before do
           allow_any_instance_of(Event::SlotsPolicy).to receive(:has_free_slot_for?).with(user) { false }
           subject.call


### PR DESCRIPTION
When the user is verified, but there's no free slots within the verified limit, the `unverified_attendee` email gets sent.