### PR TITLE
220 Improve the look of form fields that have errors

### DIFF
--- a/app/assets/stylesheets/app/shared/_input.scss
+++ b/app/assets/stylesheets/app/shared/_input.scss
@@ -28,10 +28,6 @@ $namespace: ".pk-input";
       text-align: left;
       padding: 4px 16px 0;
       color: #c52d2d;
-      &:before {
-        content: '*';
-        padding-right: 2px;
-      }
     }
   }
 

--- a/app/assets/stylesheets/app/shared/_input.scss
+++ b/app/assets/stylesheets/app/shared/_input.scss
@@ -27,10 +27,23 @@ $namespace: ".pk-input";
     .error {
       text-align: left;
       padding: 4px 16px 0;
+      color: #c52d2d;
       &:before {
         content: '*';
         padding-right: 2px;
       }
+    }
+  }
+
+  .field.error {
+    #{$namespace} {
+      -webkit-box-shadow: 0px 0px 0px 1px rgba(236, 0, 0, 1), 0px 1px 3px 0px rgba(0, 0, 0, .5) inset;
+      -moz-box-shadow: 0px 0px 0px 1px rgba(236, 0, 0, 1), 0px 1px 3px 0px rgba(0, 0, 0, .5) inset;
+      box-shadow: 0px 0px 0px 1px rgba(236, 0, 0, 1), 0px 1px 3px 0px rgba(0, 0, 0, .5) inset;
+    }
+
+    .hint {
+      display: none;
     }
   }
 }
@@ -40,7 +53,7 @@ $namespace: ".pk-input";
     width: 100%;
     height: 40px;
 
-    border-radius: 12px;
+  border-radius: 12px;
     border: 0;
     -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, .12), 0px 1px 3px 0px rgba(0, 0, 0, .5) inset;
     -moz-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, .12), 0px 1px 3px 0px rgba(0, 0, 0, .5) inset;


### PR DESCRIPTION
I wasn't sure whether we use units with 0 value in CSS by any code convention, so I left them as they were in previous styles.

I am also hiding the hint when the error message is present because it already contains the same information as the hint. And hint distracts the user from the message we are trying to convey.

The overall look of the form with errors is captured on the screenshot.
<img width="466" alt="screen shot 2017-04-08 at 10 40 48 pm" src="https://cloud.githubusercontent.com/assets/1926978/24831909/79133370-1cac-11e7-9732-8383922d8287.png">
