### PR TITLE
fix the issue when mobile menu overlaps the content and prevents the click-through

### DIFF
--- a/app/assets/stylesheets/app/base/_header.scss
+++ b/app/assets/stylesheets/app/base/_header.scss
@@ -72,6 +72,12 @@ $header-mobile-breakpoint: "420";
 }
 
 #{$namespace}__dropdown-list-wr {
+  width: 0;
+
+  .open & {
+    width: auto;
+  }
+
   @include breakpoint-max($header-menu-breakpoint) {
     position: absolute;
     top: 100%;


### PR DESCRIPTION
fix the issue when mobile menu overlaps the content and prevents the click-through