### PR TITLE
[353] Adds code highlighting to talks description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'inline_svg',                                                      '~> 1.2'
 gem 'icalendar',                                                     '~> 2.4.1'
 gem 'yt',                                                           '~> 0.30.1'
 gem 'gibbon',                                                          '~> 3.0'
+gem 'coderay',                                                       '~> 1.1.1'
 
 #=== CONFIG ===================================================================
 gem 'dotenv-rails',                                                    '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -481,6 +481,7 @@ DEPENDENCIES
   carrierwave (~> 1.0)
   chartkick (~> 2.2.3)
   codecov
+  coderay (~> 1.1.1)
   coffee-rails (~> 4.2.1)
   database_cleaner
   devise (~> 4.2)

--- a/app/assets/stylesheets/app/application.scss
+++ b/app/assets/stylesheets/app/application.scss
@@ -57,5 +57,6 @@
 @import "shared/pagination";
 @import "shared/admin";
 @import "shared/video";
+@import "shared/code";
 
 @import "external/lory";

--- a/app/assets/stylesheets/app/shared/_code.scss
+++ b/app/assets/stylesheets/app/shared/_code.scss
@@ -1,0 +1,342 @@
+.CodeRay {
+  background-color: #FFF;
+  border: 1px solid #CCC;
+  font-family: Monaco, "Courier New", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+  color: #000;
+  padding: 1em 0px 1em 1em;
+  pre {
+    margin: 0px;
+  }
+}
+
+div.CodeRay {}
+
+span.CodeRay {
+  white-space: pre;
+  border: 0px;
+  padding: 2px;
+}
+
+table.CodeRay {
+  border-collapse: collapse;
+  width: 100%;
+  padding: 2px;
+  td {
+    padding: 1em 0.5em;
+    vertical-align: top;
+  }
+}
+
+.CodeRay {
+  .line-numbers, .no {
+    background-color: #ECECEC;
+    color: #AAA;
+    text-align: right;
+  }
+  .line-numbers {
+    a {
+      color: #AAA;
+    }
+    tt {
+      font-weight: bold;
+    }
+    .highlighted {
+      color: red;
+    }
+  }
+  .line {
+    display: block;
+    float: left;
+    width: 100%;
+  }
+  span.line-numbers {
+    padding: 0px 4px;
+  }
+  .code {
+    width: 100%;
+  }
+}
+
+ol.CodeRay {
+  font-size: 10pt;
+  li {
+    white-space: pre;
+  }
+}
+
+.CodeRay {
+  .code pre {
+    overflow: auto;
+  }
+  .debug {
+    color: white ! important;
+    background: blue ! important;
+  }
+  .annotation {
+    color: #007;
+  }
+  .attribute-name {
+    color: #f08;
+  }
+  .attribute-value {
+    color: #700;
+  }
+  .binary {
+    color: #509;
+    font-weight: bold;
+  }
+  .comment {
+    color: #998;
+    font-style: italic;
+  }
+  .char {
+    color: #04D;
+    .content {
+      color: #04D;
+    }
+    .delimiter {
+      color: #039;
+    }
+  }
+  .class {
+    color: #458;
+    font-weight: bold;
+  }
+  .complex {
+    color: #A08;
+    font-weight: bold;
+  }
+  .constant {
+    color: teal;
+  }
+  .color {
+    color: #0A0;
+  }
+  .class-variable {
+    color: #369;
+  }
+  .decorator {
+    color: #B0B;
+  }
+  .definition {
+    color: #099;
+    font-weight: bold;
+  }
+  .directive {
+    color: #088;
+    font-weight: bold;
+  }
+  .delimiter {
+    color: black;
+  }
+  .doc {
+    color: #970;
+  }
+  .doctype {
+    color: #34b;
+  }
+  .doc-string {
+    color: #D42;
+    font-weight: bold;
+  }
+  .escape {
+    color: #666;
+    font-weight: bold;
+  }
+  .entity {
+    color: #800;
+    font-weight: bold;
+  }
+  .error {
+    color: #F00;
+    background-color: #FAA;
+  }
+  .exception {
+    color: #C00;
+    font-weight: bold;
+  }
+  .filename {
+    color: #099;
+  }
+  .function {
+    color: #900;
+    font-weight: bold;
+  }
+  .global-variable {
+    color: teal;
+    font-weight: bold;
+  }
+  .hex {
+    color: #058;
+    font-weight: bold;
+  }
+  .integer {
+    color: #099;
+  }
+  .include {
+    color: #B44;
+    font-weight: bold;
+  }
+  .inline {
+    color: black;
+    .inline {
+      background: #ccc;
+      .inline {
+        background: #bbb;
+      }
+    }
+    .inline-delimiter {
+      color: #D14;
+    }
+  }
+  .inline-delimiter {
+    color: #D14;
+  }
+  .important {
+    color: #f00;
+  }
+  .interpreted {
+    color: #B2B;
+    font-weight: bold;
+  }
+  .instance-variable {
+    color: teal;
+  }
+  .label {
+    color: #970;
+    font-weight: bold;
+  }
+  .local-variable {
+    color: #963;
+  }
+  .octal {
+    color: #40E;
+    font-weight: bold;
+  }
+  .operator {}
+  .predefined-constant {
+    font-weight: bold;
+  }
+  .predefined {
+    color: #369;
+    font-weight: bold;
+  }
+  .preprocessor {
+    color: #579;
+  }
+  .pseudo-class {
+    color: #00C;
+    font-weight: bold;
+  }
+  .predefined-type {
+    color: #074;
+    font-weight: bold;
+  }
+  .reserved {
+    color: #000;
+    font-weight: bold;
+  }
+}
+
+.keyword {
+  color: #000;
+  font-weight: bold;
+}
+
+.CodeRay {
+  .key {
+    color: #808;
+    .delimiter {
+      color: #606;
+    }
+    .char {
+      color: #80f;
+    }
+  }
+  .value {
+    color: #088;
+  }
+  .regexp {
+    background-color: #fff0ff;
+    .content {
+      color: #808;
+    }
+    .delimiter {
+      color: #404;
+    }
+    .modifier {
+      color: #C2C;
+    }
+    .function {
+      color: #404;
+      font-weight: bold;
+    }
+  }
+  .string {
+    color: #D20;
+    .string .string {
+      background-color: #ffd0d0;
+    }
+    .content, .char, .delimiter {
+      color: #D14;
+    }
+  }
+  .shell {
+    color: #D14;
+    .content {}
+    .delimiter {
+      color: #D14;
+    }
+  }
+  .symbol {
+    color: #990073;
+    .content {
+      color: #A60;
+    }
+    .delimiter {
+      color: #630;
+    }
+  }
+  .tag {
+    color: #070;
+  }
+  .tag-special {
+    color: #D70;
+    font-weight: bold;
+  }
+  .type {
+    color: #339;
+    font-weight: bold;
+  }
+  .variable {
+    color: #036;
+  }
+  .insert {
+    background: #afa;
+  }
+  .delete {
+    background: #faa;
+  }
+  .change {
+    color: #aaf;
+    background: #007;
+  }
+  .head {
+    color: #f8f;
+    background: #505;
+  }
+  .insert .insert {
+    color: #080;
+    font-weight: bold;
+  }
+  .delete .delete {
+    color: #800;
+    font-weight: bold;
+  }
+  .change .change {
+    color: #66f;
+  }
+  .head .head {
+    color: #f4f;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,10 @@ module ApplicationHelper
     "#{formatted_date} #{delimiter} #{formatted_time}"
   end
 
+  def markdownify(content)
+    MarkdownRenderer.call(content)
+  end
+
   def unauthorized_message(action_message)
     return if current_user
 

--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -12,10 +12,27 @@ class MarkdownRenderer < ApplicationService
   attr_reader :text
 
   def markdown
-    @markdown ||= ::Redcarpet::Markdown.new(renderer, extensions = {})
+    @markdown ||= ::Redcarpet::Markdown.new(renderer, extensions)
   end
 
   def renderer
-    @renderer ||= ::Redcarpet::Render::HTML.new(render_options = {autolink: true})
+    @renderer ||= ::Renderers::Code.new(render_options)
+  end
+
+  def render_options
+    {
+      filter_html: true,
+      hard_wrap:   true,
+    }
+  end
+
+  def extensions
+    {
+      fenced_code_blocks: true,
+      no_intra_emphasis:  true,
+      autolink:           true,
+      lax_html_blocks:    true,
+      superscript:        true
+    }
   end
 end

--- a/app/services/renderers/code.rb
+++ b/app/services/renderers/code.rb
@@ -1,0 +1,7 @@
+module Renderers
+  class Code < ::Redcarpet::Render::HTML
+    def block_code(code, language)
+      ::CodeRay.scan(code, language).div
+    end
+  end
+end

--- a/app/views/talks/show.slim
+++ b/app/views/talks/show.slim
@@ -17,7 +17,7 @@
     .pk-container
       .pk-talk-content__container
         .pk-talk-content__left
-          = talk.description
+          = markdownify(talk.description)
         .pk-talk-content__right
           .pk-talk-content__link-area
             = talk_slides_url(talk, class: "pk-link pk-link--btn pk-talk-content__link")


### PR DESCRIPTION
Adds code highlighting which looks like this
![example](https://cloud.githubusercontent.com/assets/13320669/26308691/e5b7784c-3f02-11e7-9be3-2f1f54c70034.png)

Currently it uses Github's theme which doesn't play well with the current design but we can change it using `shared/code.scss`