### PR TITLE
add capistrano3-postgres for easy database operations

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,6 +36,7 @@ require "capistrano/rails/migrations"
 # require "capistrano/passenger"
 require 'slackistrano/capistrano'
 require_relative 'lib/slackistrano/custom_messaging'
+require 'capistrano3/postgres'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'faker'
   gem 'bullet'
+  gem 'capistrano3-postgres', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     capistrano-sidekiq (0.10.0)
       capistrano
       sidekiq (>= 3.4)
+    capistrano3-postgres (0.2.3)
     capybara (2.13.0)
       addressable
       mime-types (>= 1.16)
@@ -477,6 +478,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.2)
   capistrano-rvm
   capistrano-sidekiq
+  capistrano3-postgres
   capybara
   carrierwave (~> 1.0)
   chartkick (~> 2.2.3)
@@ -550,4 +552,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,6 +28,9 @@ set :slackistrano, {
   webhook: ENV['slackistrano_SLACK_WEBHOOK']
 }
 
+set :postgres_remote_cluster, '9.6/main'
+set :postgres_backup_compression_level, 6 # Will use gzip level 6 to compress the output.
+
 namespace :foreman do
   desc "Export the Procfile to Ubuntu's upstart scripts"
   task :export do


### PR DESCRIPTION
It will allow easy replication from server environments databases to local development database as: 
cap production postgres:replicate # Performs create, download and import, step by step.