### PR TITLE
Sort admin talks by date (#395)

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -33,7 +33,7 @@ module Admin
     def talks
       @talks ||= search_against(Talk)
         .includes(:tags, :event, :speaker, :group)
-        .page(params[:page])
+        .page(params[:page]).sorted_by_date
     end
 
     def talks_params

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -11,7 +11,8 @@ class Talk < ApplicationRecord
   belongs_to :speaker, class_name: 'User'
   belongs_to :group
 
-  scope :sorted, -> { order(:title) }
+  scope :sorted,         -> { order(:title) }
+  scope :sorted_by_date, -> { order(:created_at) }
 
   validates :title, presence: true
 

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -12,7 +12,7 @@ class Talk < ApplicationRecord
   belongs_to :group
 
   scope :sorted,         -> { order(:title) }
-  scope :sorted_by_date, -> { order(:created_at) }
+  scope :sorted_by_date, -> { order(created_at: :desc) }
 
   validates :title, presence: true
 

--- a/spec/features/admin/talks/read_spec.rb
+++ b/spec/features/admin/talks/read_spec.rb
@@ -47,4 +47,17 @@ RSpec.describe 'Talks READ' do
     it { expect(page).to have_link 'Test Talk with User' }
     it { expect(page).to have_content 'Super User' }
   end
+
+  context 'talks list should be ordered by creation_date desc' do
+    let!(:talk_firstly_created)    { create(:talk, title: 'Test Talk A') }
+    let!(:talk_secondly_created)   { create(:talk, title: 'Test Talk B') }
+    let!(:talk_lastly_created)     { create(:talk, title: 'Test Talk C') }
+
+    before do
+      assume_admin_logged_in
+      visit '/admin/talks'
+    end
+
+      it { expect(page).to have_text(/(Test Talk C).+(Test Talk B).+(Test Talk A)/) }
+  end
 end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Talk do
   end
 
   it 'applies a scope to talk collections by created_date' do
-    expect(Talk.all.sorted_by_date.to_sql).to eq Talk.all.order(created_at: :asc).to_sql
+    expect(Talk.all.sorted_by_date.to_sql).to eq Talk.all.order(created_at: :desc).to_sql
   end
 end

--- a/spec/models/talk_spec.rb
+++ b/spec/models/talk_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe Talk do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:title) }
   end
+
+  it 'applies a scope to talk collections by created_date' do
+    expect(Talk.all.sorted_by_date.to_sql).to eq Talk.all.order(created_at: :asc).to_sql
+  end
 end


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/395)

### Description

talks on admin page had no order and it was a little bit inconvenient. so talk order has been changed, now it is sorted by created_at field and descending order.

### How to test instructions
**repro steps:**
1. navigate http://localhost:3000/admin/talks
2. run rails console and execute:
  Talk.all.order(created_at: :desc).first(3).map { |talk| "#{talk.title} #{talk.created_at}" }
3. compare results from admin's talk page and output in rails console

4.switch to branch with fix "sort_admin_talks_by_date"
5. perform first 3 steps again

**Expected result:**
after switching to branch with fix, 3rd step should show same talks order.

### Pre-merge checklist

- [+ ] The PR relates to a single subject with a clear title and description
- [ +] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |

BEFORE:
| ![before_talks_list](https://user-images.githubusercontent.com/10061671/28010348-4b20a174-6567-11e7-8e44-5284e8f5224c.png)

AFTER:
 ![after_talks_list](https://user-images.githubusercontent.com/10061671/28010353-4e761cd2-6567-11e7-9cb6-60c1b97a1aef.png) |




