### PR TITLE
Attend user from wait list after someone from main list cancel visit request

### DIFF
--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -15,7 +15,7 @@ module Admin
     end
 
     def visit_requests
-      @visit_requests ||= search_against(base_scope).includes(:user, :event).order(:id)
+      @visit_requests ||= search_against(base_scope).includes(:user).order(:id)
     end
 
     def base_scope

--- a/app/controllers/visit_requests_controller.rb
+++ b/app/controllers/visit_requests_controller.rb
@@ -14,7 +14,7 @@ class VisitRequestsController < ApplicationController
   end
 
   def destroy
-    visit_request.destroy
+    VisitRequest::Cancel.call(visit_request)
 
     flash_success and default_redirect
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -35,14 +35,17 @@ module EventsHelper
       t('visit_requests.messages.see_you')
     elsif visit_request.refused?
       t('visit_requests.messages.so_pity')
+    elsif visit_request.canceled?
+      t('visit_requests.messages.canceled')
     else
-    t('visit_requests.messages.please_confirm')
+      t('visit_requests.messages.please_confirm')
     end
   end
 
   def visit_request_confirm_link(visit_request)
     return unless visit_request && current_user
     return if visit_request.final_decision?
+    return if visit_request.canceled?
 
     link_to t('visit_requests.confirm'),
       visit_request_confirm_path(visit_request, :yes),
@@ -52,6 +55,7 @@ module EventsHelper
   def visit_request_refuse_link(visit_request)
     return unless visit_request && current_user
     return if visit_request.final_decision?
+    return if visit_request.canceled?
 
     link_to t('visit_requests.refuse'),
       visit_request_confirm_path(visit_request, :no),

--- a/app/services/visit_request/cancel.rb
+++ b/app/services/visit_request/cancel.rb
@@ -6,10 +6,23 @@ class VisitRequest
 
     def call
       visit_request.canceled!
+      attend_first_user_from_waitlist
     end
 
     private
 
     attr_reader :visit_request
+
+    def attend_first_user_from_waitlist
+      if waiting_list_request = VisitRequest.where(waiting_list: true).first
+        waiting_list_request.waiting_list = false
+        waiting_list_request.save
+        if visit_request.event.status == 'registration'
+          VisitRequest::Approve.call(waiting_list_request)
+        else
+          VisitRequest::FinalConfirmation(waiting_list_request)
+        end
+      end
+    end
   end
 end

--- a/app/services/visit_request/cancel.rb
+++ b/app/services/visit_request/cancel.rb
@@ -14,14 +14,14 @@ class VisitRequest
     attr_reader :visit_request
 
     def attend_first_user_from_waitlist
-      if waiting_list_request = VisitRequest.where(waiting_list: true).first
-        waiting_list_request.waiting_list = false
-        waiting_list_request.save
-        if visit_request.event.status == 'registration'
-          VisitRequest::Approve.call(waiting_list_request)
-        else
-          VisitRequest::FinalConfirmation(waiting_list_request)
-        end
+      return unless waiting_list_request = VisitRequest.waiting_list.first
+
+      waiting_list_request.main_list!
+
+      if visit_request.event.registration?
+        VisitRequest::Approve.call(waiting_list_request)
+      else
+        VisitRequest::FinalConfirmation(waiting_list_request)
       end
     end
   end

--- a/spec/features/visit_requests/cancel_spec.rb
+++ b/spec/features/visit_requests/cancel_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe 'Visit Requests CANCEL' do
     visit "/events/#{event.slug}"
   end
 
+  describe 'event page' do
+    it { expect(page).to_not have_link 'Attend' }
+    it { expect(page).to have_link 'Cancel attendance' }
+  end
+
   it 'changes visit request status to canceled' do
     expect { click_link 'Cancel attendance'}.to change{ visit_request.reload.status }.to ('canceled')
     expect(page).to have_content I18n.t('visit_requests.messages.canceled')

--- a/spec/features/visit_requests/cancel_spec.rb
+++ b/spec/features/visit_requests/cancel_spec.rb
@@ -2,14 +2,34 @@ RSpec.describe 'Visit Requests CANCEL' do
   let(:event)          { create(:event) }
   let(:user)           { create(:user)  }
   let!(:visit_request) { create(:visit_request, user: user, event: event) }
+  let!(:waiting_visit_request) {
+    create(
+      :visit_request,
+      user: user,
+      event: event,
+      waiting_list: true
+    )
+  }
 
   before do
     assume_logged_in(user)
     visit "/events/#{event.slug}"
   end
 
-  it 'removes visit request from database' do
-    expect { click_link 'Cancel attendance'}.to change{VisitRequest.count}.by(-1)
-    expect(page).to have_link 'Attend'
+  it 'changes visit request status to canceled' do
+    expect { click_link 'Cancel attendance'}.to change{ visit_request.reload.status }.to ('canceled')
+    expect(page).to have_content I18n.t('visit_requests.messages.canceled')
+  end
+
+  it 'changes visit request status from waiting list to approved' do
+    expect { click_link 'Cancel attendance'}
+      .to change{ waiting_visit_request.reload.status }
+      .to('approved')
+  end
+
+  it 'changes waiting list count by one' do
+    expect { click_link 'Cancel attendance'}
+      .to change{ VisitRequest.waiting_list.count }
+      .by(-1)
   end
 end


### PR DESCRIPTION
Resolves [github issue #240 ](https://github.com/pivorakmeetup/pivorak-web-app/issues/240)

### Description

Set first user from waiting list to main list when user from main list cancel visit request

### How to test instructions

Create event.

Set `limit total` and `limit verified` to 1

Event should have `registration` status

---

Login as verified user

Should see `Attend` link at event page

Click `Attend` link

Should see successful confirm message `You have been confirmed for this event!`

Should see `Cancel attendance` link

Logout

---

Login as another verified user

Should see `Seems like all seats have been 
taken, but you can add yourself to waiting list`

Should see `Attend` link

After click on `Attend link` shoud see `Your event request is under review. we'll get back to you asap` message.

Shoud see `Cancel attedance` link

Click at `Cancel attedance` link

Should see `Sorry, but have canceled your visit request`

### Pre-merge checklist
 
- [x] The PR relates to a single subject with a clear title and description
- [x] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| ![alt text](http://pix.toile-libre.org/upload/original/1499753535.png)| ![alt](http://pix.toile-libre.org/upload/original/1499753991.png)|


