### PR TITLE
#412 fix event is shown with default limits

### DIFF
--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -15,6 +15,16 @@ module Admin
         admin_event_visit_requests_path(event), options
     end
 
+    def default_limit_total
+      return event.limit_total if Event.exists?(event)
+      Ez::Settings[:app, :events, :default_limit]
+    end
+
+    def default_limit_verified
+      return event.limit_verified if Event.exists?(event)
+      Ez::Settings[:app, :events, :default_limit_verified]
+    end
+
     def event_status_label(event)
       content_tag :span, event.status,
         class: ['ui label', BG_STATUS_CLASS[event.status.to_sym]]

--- a/app/views/admin/events/form.slim
+++ b/app/views/admin/events/form.slim
@@ -26,8 +26,8 @@
     .eight.wide.field
       = f.input :description, input_html: { rows: 10 }
       .two.fields
-        = f.input :limit_total,    input_html: { value: Ez::Settings[:app, :events, :default_limit] }
-        = f.input :limit_verified, input_html: { value: Ez::Settings[:app, :events, :default_limit_verified] }
+        = f.input :limit_total,    input_html: { value: default_limit_total }
+        = f.input :limit_verified, input_html: { value: default_limit_verified }
       .two.fields
         = f.input :started_at,  as: :string
         = f.input :finished_at, as: :string

--- a/spec/features/admin/events/create_spec.rb
+++ b/spec/features/admin/events/create_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe 'Events CREATE' do
 
     it 'should have default values' do
       expect(
-        Time.zone.parse(
-          find("#event_started_at").value
-        ).hour
+          Time.zone.parse(
+              find("#event_started_at").value
+          ).hour
       ).to eq(default_started_at_hour)
 
       expect(
-        Time.zone.parse(
-          find("#event_finished_at").value
-        ).hour
+          Time.zone.parse(
+              find("#event_finished_at").value
+          ).hour
       ).to eq(default_finished_at_hour)
     end
   end
@@ -72,6 +72,26 @@ RSpec.describe 'Events CREATE' do
       click_button 'Create Event'
 
       expect(Event.last.facebook_embeded_post).to be_present
+    end
+  end
+
+  context 'Limit inputs' do
+    let(:default_limit_total)      { Ez::Settings[:app, :events, :default_limit] }
+    let(:default_limit_verified)   { Ez::Settings[:app, :events, :default_limit_verified] }
+
+    it 'should have default values' do
+      expect(page).to have_field('Limit total', with: default_limit_total)
+      expect(page).to have_field('Limit verified', with: default_limit_verified)
+    end
+
+    it 'should show defined values after creation' do
+      fill_in 'Title', with: 'Super New Event'
+      fill_in 'Limit total', with: 2
+      fill_in 'Limit verified', with: 1
+      click_button 'Create Event'
+
+      expect(page).to have_field('Limit total', with: 2)
+      expect(page).to have_field('Limit verified', with: 1)
     end
   end
 end

--- a/spec/features/admin/events/create_spec.rb
+++ b/spec/features/admin/events/create_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe 'Events CREATE' do
 
     it 'should have default values' do
       expect(
-          Time.zone.parse(
-              find("#event_started_at").value
-          ).hour
+        Time.zone.parse(
+          find("#event_started_at").value
+        ).hour
       ).to eq(default_started_at_hour)
 
       expect(
-          Time.zone.parse(
-              find("#event_finished_at").value
-          ).hour
+        Time.zone.parse(
+          find("#event_finished_at").value
+        ).hour
       ).to eq(default_finished_at_hour)
     end
   end

--- a/spec/features/admin/events/update_spec.rb
+++ b/spec/features/admin/events/update_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe 'Events UPDATE' do
       expect(page).to have_current_path '/admin/events/test-event/edit'
     end
   end
+
+  context 'default values for event' do
+    it 'shows updated values instead of default' do
+      fill_in 'Title',  with: 'Super New Event'
+      fill_in 'Limit total', with: 2
+      fill_in 'Limit verified', with: 1
+      click_button 'Update Event'
+
+      expect_success_flash_message 'Event', 'updated'
+      expect(page).to have_field('Limit total', with: '2')
+      expect(page).to have_field('Limit verified', with: '1')
+    end
+  end
 end


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/412)

### Description

Limit total and Limit verified fields on http://localhost:3000/admin/events/new show predefined default values which is correct, incorrect is that it shows same default values after an event object is created instead of defined values. 

### How to test instructions

**Repro steps:**
1. Go to http://localhost:3000/admin/events/new
2. Fill fields Limit total with 1 and Limit verified with 1
3. Save
**Expected result:** Limit fields should contain **defined** values 
**Actual result:** Limit total and Limit verified contain default values

**Test steps:**
1. Go to http://localhost:3000/admin/events/new
2. rendered form should show up default values 50 and 35 by default
3. Fill fields Limit total with 1 and Limit verified with 1
4. Save
5. rendered form now should show **defined** values 1 and 1 respectively
### Pre-merge checklist
 
- [+ ] The PR relates to a single subject with a clear title and description
- [ +] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
![new_event_with_defaults](https://user-images.githubusercontent.com/10061671/28058311-ea45d1ee-6629-11e7-8df8-13deb5e143a2.png) | ![after_create_event_defaults](https://user-images.githubusercontent.com/10061671/28058450-eef6b212-6629-11e7-9d12-16ac31b31247.png)



