### PR TITLE
#420 Add missed translation at login and sign up page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
     not_assigned: 'not assigned'
     unauthorized: 'Please <a href=%{login_url}>log in</a> or <a href=%{register_url}>register</a> and then enroll in this event to attend'
     not_assigned: Not assigned
+    default_title: '#pivorak Lviv Ruby User Group'
 
   settings:
     plural: Settings


### PR DESCRIPTION
Resolves [github issue #420 ](https://github.com/pivorakmeetup/pivorak-web-app/issues/420)

### Description

Translation missing in page title on signup and login page

### How to test instructions

Go to https://pivorak.com/users/sign_in or https://pivorak.com/users/sign_up
You shouldn't see message about missed translation in page title`<span class="translation_missing" title="translation missing: en.phrases.default_title">Default Title</span>`

### Pre-merge checklist
 
- [x] The PR relates to a single subject with a clear title and description
- [x] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| ![](http://pix.toile-libre.org/upload/original/1499860280.png) | ![](http://pix.toile-libre.org/upload/original/1499860181.png) |


