### PR TITLE
#388 Allow user to cancel event attendance after confirmation.

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -51,7 +51,7 @@ module EventsHelper
 
   def visit_request_refuse_link(visit_request)
     return unless visit_request && current_user
-    return if visit_request.final_decision?
+    return if visit_request.refused?
 
     link_to t('visit_requests.refuse'),
       visit_request_confirm_path(visit_request, :no),

--- a/spec/features/visit_requests/confirmation_spec.rb
+++ b/spec/features/visit_requests/confirmation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Visit Requests CONFIRMATION' do
     it { expect(page).to have_content I18n.t('flash.visit_requests.show.confirmed') }
     it { expect(page).to_not have_content I18n.t('visit_requests.messages.so_pity') }
     it { expect(page).to_not have_link 'Confirm' }
-    it { expect(page).to_not have_link 'Refuse' }
+    it { expect(page).to have_link 'Refuse' }
   end
 
   context 'Click Refuse' do


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/388)

### Description

Allow user to cancel event attendance after confirmation.

### How to test instructions

1. Attend to event.
2. Move event to confirmation state.
3. Confirm event attendance.

### Pre-merge checklist
 
- [ ] The PR relates to a single subject with a clear title and description
- [ ] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/11468173/28228408-1165e10a-68e7-11e7-9a70-1411b012c0ed.png) | ![image](https://user-images.githubusercontent.com/11468173/28228431-317249ac-68e7-11e7-9cd6-e2ef74c63601.png) |


