### PR TITLE
#436 send email to admin if visit request canceled

### DIFF
--- a/app/controllers/visit_requests_controller.rb
+++ b/app/controllers/visit_requests_controller.rb
@@ -15,7 +15,7 @@ class VisitRequestsController < ApplicationController
   end
 
   def destroy
-    visit_request.destroy
+    VisitRequest::Cancel.call(visit_request)
 
     flash_success and default_redirect
   end

--- a/app/mailer_previews/visit_request_mailer_preview.rb
+++ b/app/mailer_previews/visit_request_mailer_preview.rb
@@ -11,9 +11,12 @@ class VisitRequestMailerPreview
     VisitRequestMailer.needs_confirmation visit_request
   end
 
-
   def notify_admin_about_unverified_attendee
     VisitRequestMailer.notify_admin_about_unverified_attendee visit_request
+  end
+
+  def notify_admin_about_canceled_attendee
+    VisitRequestMailer.notify_admin_about_canceled_attendee visit_request
   end
 
   private

--- a/app/mailers/visit_request_mailer.rb
+++ b/app/mailers/visit_request_mailer.rb
@@ -38,4 +38,13 @@ class VisitRequestMailer < ApplicationMailer
       format.html { email_template.render(user: @user, event: @event) }
     end
   end
+
+  def notify_admin_about_canceled_attendee(visit_request)
+    @user = visit_request.user
+    @event = visit_request.event
+
+    mail(to: PIVORAK_EMAIL, from: NO_REPLY_EMAIL, subject: email_template.subject) do |format|
+      format.html { email_template.render(user: @user, event: @event) }
+    end
+  end
 end

--- a/app/services/visit_request/cancel.rb
+++ b/app/services/visit_request/cancel.rb
@@ -6,6 +6,7 @@ class VisitRequest
 
     def call
       visit_request.canceled!
+      VisitRequestMailer.notify_admin_about_canceled_attendee(visit_request).deliver_later
     end
 
     private

--- a/db/migrate/20170714191645_seed_notify_admin_about_canceled_attendee.rb
+++ b/db/migrate/20170714191645_seed_notify_admin_about_canceled_attendee.rb
@@ -1,0 +1,14 @@
+class SeedNotifyAdminAboutCanceledAttendee < ActiveRecord::Migration[5.0]
+  def up
+    EmailTemplate.create!(
+      title: 'VisitRequestMailer#notify_admin_about_canceled_attendee',
+      subject: 'Attendee canceled his request',
+      note: 'Will be sent when attendee cancels his request',
+      body: File.read('db/seed/email_templates/notify_admin_about_canceled_attendee.md'),
+    )
+  end
+
+  def down
+    EmailTemplate.delete_all(title: 'VisitRequestMailer#notify_admin_about_canceled_attendee')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 20170714191645) do
   create_table "email_templates", force: :cascade do |t|
     t.string   "title"
     t.string   "subject"
-    t.string   "from"
     t.text     "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520084316) do
+ActiveRecord::Schema.define(version: 20170714191645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20170520084316) do
   create_table "email_templates", force: :cascade do |t|
     t.string   "title"
     t.string   "subject"
+    t.string   "from"
     t.text     "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seed/email_templates/notify_admin_about_canceled_attendee.md
+++ b/db/seed/email_templates/notify_admin_about_canceled_attendee.md
@@ -1,0 +1,2 @@
+User #{@user.full_name} canceled request to #{@event.title}.
+Please approve new user [here](#{admin_visit_requests_url}).

--- a/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_1.yml
+++ b/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_1.yml
@@ -137,4 +137,244 @@ http_interactions:
         }
     http_version: 
   recorded_at: Sat, 20 May 2017 11:13:30 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:08 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:08 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:11 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:11 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:11 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:24 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:24 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:47 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:47 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_2.yml
+++ b/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_2.yml
@@ -137,4 +137,244 @@ http_interactions:
         }
     http_version: 
   recorded_at: Sat, 20 May 2017 11:13:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:47 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:47 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:47 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:28:51 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:28:51 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:28:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:29:04 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:29:04 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:29:04 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:29:27 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:29:27 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:29:27 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_3.yml
+++ b/spec/cassettes/Talk_FetchExternalVideoData/_call/valid_video_url/1_1_1_3.yml
@@ -137,4 +137,244 @@ http_interactions:
         }
     http_version: 
   recorded_at: Sat, 20 May 2017 11:13:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:29:27 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:29:27 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:29:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:29:30 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:29:30 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:29:30 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:29:44 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:29:44 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:29:43 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=4QdOwMVMs7k&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      User-Agent:
+      - Yt::Request (gzip)
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin,Accept-Encoding
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 15 Jul 2017 13:30:07 GMT
+      Expires:
+      - Sat, 15 Jul 2017 13:30:07 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,36,35"
+      Accept-Ranges:
+      - none
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "usageLimits",
+            "reason": "dailyLimitExceededUnreg",
+            "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+            "extendedHelp": "https://code.google.com/apis/console"
+           }
+          ],
+          "code": 403,
+          "message": "Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 15 Jul 2017 13:30:07 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/admin/emails/preview_spec.rb
+++ b/spec/features/admin/emails/preview_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe 'Emails PREVIEW' do
         expect(page.status_code).to eq(200)
       end
     end
+
+    describe 'VisitRequestMailer#notify_admin_about_canceled_attendee' do
+      it do
+        EmailTemplate.create!(
+          title: 'VisitRequestMailer#notify_admin_about_canceled_attendee',
+          subject: 'Attendee canceled his request',
+          note: 'Will be sent when attendee cancels his request',
+          body: File.read('db/seed/email_templates/notify_admin_about_canceled_attendee.md')
+        )
+        create(:visit_request)
+        visit '/emails/en/visit_request_mailer_preview-notify_admin_about_canceled_attendee'
+        expect(page.status_code).to eq(200)
+      end
+    end
   end
 
   context 'when user is not admin' do

--- a/spec/features/visit_requests/cancel_spec.rb
+++ b/spec/features/visit_requests/cancel_spec.rb
@@ -1,24 +1,45 @@
 RSpec.describe 'Visit Requests CANCEL' do
-  subject              { click_link 'Cancel attendance'}
   let(:event)          { create(:event) }
   let(:user)           { create(:user)  }
   let!(:visit_request) { create(:visit_request, user: user, event: event) }
 
-  before do
-    assume_logged_in(user)
-    visit "/events/#{event.slug}"
+  context 'when user is not logged in' do
+    before do
+      visit "/events/#{event.id}"
+    end
+
+    describe 'event page' do
+      it { expect(page).to_not have_link 'Attend' }
+      it { expect(page).to have_content 'Please log in or register and then enroll in this event to attend' }
+    end
   end
 
-  it 'changes visit request status to canceled' do
-    expect { click_link 'Cancel attendance'}.to change{ visit_request.reload.status }.to (VisitRequest::CANCELED.to_s)
-    expect(page).to have_content 'Pity.. Hope to see you next time!'
-  end
+  context 'when user is logged in' do
+    before do
+      assume_logged_in(user)
+      visit "/events/#{event.slug}"
+    end
 
-  it 'sends email to admin' do
-    click_link 'Cancel attendance'
-    active_job = active_jobs[0]
-    expect(active_job[:job]).to eq ActionMailer::DeliveryJob
-    expect(active_job[:args][0]).to eq 'VisitRequestMailer'
-    expect(active_job[:args][1]).to eq 'notify_admin_about_canceled_attendee'
+    describe "click 'Cancel attendance'" do
+      before { click_link 'Cancel attendance' }
+
+      it { expect(page).to have_current_path("/") }
+      it { expect(page).to_not have_link 'Attend' }
+
+      it 'changes visit request status to canceled' do
+        expect(visit_request.reload.status).to eq(VisitRequest::CANCELED.to_s)
+      end
+
+      it 'shows flash message' do
+        expect(page).to have_content I18n.t('flash.visit_requests.destroy.success')
+      end
+
+      it 'sends email to admin' do
+        active_job = active_jobs[0]
+        expect(active_job[:job]).to eq ActionMailer::DeliveryJob
+        expect(active_job[:args][0]).to eq 'VisitRequestMailer'
+        expect(active_job[:args][1]).to eq 'notify_admin_about_canceled_attendee'
+      end
+    end
   end
 end

--- a/spec/features/visit_requests/cancel_spec.rb
+++ b/spec/features/visit_requests/cancel_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe 'Visit Requests CANCEL' do
+  subject              { click_link 'Cancel attendance'}
   let(:event)          { create(:event) }
   let(:user)           { create(:user)  }
   let!(:visit_request) { create(:visit_request, user: user, event: event) }
@@ -8,8 +9,16 @@ RSpec.describe 'Visit Requests CANCEL' do
     visit "/events/#{event.slug}"
   end
 
-  it 'removes visit request from database' do
-    expect { click_link 'Cancel attendance'}.to change{VisitRequest.count}.by(-1)
-    expect(page).to have_link 'Attend'
+  it 'changes visit request status to canceled' do
+    expect { click_link 'Cancel attendance'}.to change{ visit_request.reload.status }.to (VisitRequest::CANCELED.to_s)
+    expect(page).to have_content 'Pity.. Hope to see you next time!'
+  end
+
+  it 'sends email to admin' do
+    click_link 'Cancel attendance'
+    active_job = active_jobs[0]
+    expect(active_job[:job]).to eq ActionMailer::DeliveryJob
+    expect(active_job[:args][0]).to eq 'VisitRequestMailer'
+    expect(active_job[:args][1]).to eq 'notify_admin_about_canceled_attendee'
   end
 end

--- a/spec/mailers/visit_request_mailer_spec.rb
+++ b/spec/mailers/visit_request_mailer_spec.rb
@@ -77,4 +77,28 @@ describe VisitRequestMailer do
       expect(mail.body.encoded).to include user.full_name
     end
   end
+
+  describe '#notify_admin_about_canceled_attendee' do
+    let(:mail) { described_class.notify_admin_about_canceled_attendee(visit_request) }
+    let!(:email_template) do
+      EmailTemplate.create!(
+        title: 'VisitRequestMailer#notify_admin_about_canceled_attendee',
+        subject: 'Attendee canceled his request',
+        note: 'Will be sent when attendee cancels his request',
+        body: File.read('db/seed/email_templates/notify_admin_about_canceled_attendee.md')
+      )
+    end
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq(email_template.subject)
+      expect(mail.to).to eq([ApplicationMailer::PIVORAK_EMAIL])
+      expect(mail.from).to eq([ApplicationMailer::NO_REPLY_EMAIL])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to include event.title
+      expect(mail.body.encoded).to include user.full_name
+      expect(mail.body.encoded).to have_link('here', href: "http://localhost/admin/events/#{event.slug}/visit_requests")
+    end
+  end
 end

--- a/spec/services/visit_request/cancel_spec.rb
+++ b/spec/services/visit_request/cancel_spec.rb
@@ -13,9 +13,5 @@ describe VisitRequest::Cancel do
 
       expect(visit_request.reload.status).to eq(VisitRequest::CANCELED.to_s)
     end
-
-    it 'sends email to admin' do
-      subject.call
-    end
   end
 end

--- a/spec/services/visit_request/cancel_spec.rb
+++ b/spec/services/visit_request/cancel_spec.rb
@@ -13,5 +13,9 @@ describe VisitRequest::Cancel do
 
       expect(visit_request.reload.status).to eq(VisitRequest::CANCELED.to_s)
     end
+
+    it 'sends email to admin' do
+      subject.call
+    end
   end
 end


### PR DESCRIPTION
Resolves [github issue #436 ](https://github.com/pivorakmeetup/pivorak-web-app/issues/x)

### Description

Sends email to admin when user cencel visit request to event

### How to test instructions

Attend to some event
Cancel visit request at event page
Admin shoud receive email about canceled visit request

### Pre-merge checklist
 
- [x] The PR relates to a single subject with a clear title and description
- [x] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| Insert screenshots and/or screen recordings | Insert screenshots and/or screen recordings |
