### PR TITLE
#441 Add interview assessments

### DIFF
--- a/components/courses/app/controllers/admin/courses/interview_assessments_controller.rb
+++ b/components/courses/app/controllers/admin/courses/interview_assessments_controller.rb
@@ -1,0 +1,34 @@
+module Admin
+  module Courses
+    class InterviewAssessmentsController < BaseController
+      helper_method :interview, :assessment
+
+      def create
+        interview.interview_assessments.create(interview_assessment_params)
+      end
+
+      def update
+        assessment.update(interview_assessment_params)
+      end
+
+      private
+
+      def interview
+        ::Courses::Interview.find(params[:interview_id])
+      end
+
+      def assessment
+        ::Courses::InterviewAssessment.find(params[:id])
+      end
+
+      def interview_assessment_params
+        params.require(:interview_assessment).permit(:mark, :question_id).merge(mentor_id: mentor_id)
+      end
+
+      def mentor_id
+        ::Courses::Mentor
+          .find_by(season_id: current_season.id, user_id: current_user.id).id
+      end
+    end
+  end
+end

--- a/components/courses/app/controllers/admin/courses/interviews_controller.rb
+++ b/components/courses/app/controllers/admin/courses/interviews_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   module Courses
     class InterviewsController < BaseController
-      helper_method :interviews, :interview
+      helper_method :interviews, :interview, :assessment, :questions
 
       breadcrumps do
         add :interviews_breadcrumb
@@ -16,6 +16,10 @@ module Admin
       def create
         @interview = current_season.interviews.new(interviews_params)
         react_to interview.save
+      end
+
+      def show
+        @average_assessment = ::Courses::Interview::AverageAssessment.new(interview, questions).call
       end
 
       def update
@@ -59,6 +63,16 @@ module Admin
       def mentor_id
         ::Courses::Mentor
           .find_by(season_id: current_season.id, user_id: current_user.id).id
+      end
+
+      def assessment(interview, question)
+        ::Courses::InterviewAssessment.find_or_initialize_by(mentor_id:    interview.mentor_id,
+                                                             interview_id: interview.id,
+                                                             question_id:  question.id)
+      end
+
+      def questions
+        current_season.questions
       end
     end
   end

--- a/components/courses/app/controllers/admin/courses/test_task_controller.rb
+++ b/components/courses/app/controllers/admin/courses/test_task_controller.rb
@@ -37,7 +37,6 @@ module Admin
         add_breadcrumb 'test_tasks.plural',
           path: admin_courses_season_test_task_index_path(current_season)
       end
-     end
     end
   end
 end

--- a/components/courses/app/helpers/admin/courses/interview_helper.rb
+++ b/components/courses/app/helpers/admin/courses/interview_helper.rb
@@ -8,6 +8,30 @@ module Admin
       def interview_form_method
         params[:action] == 'edit' ? :put : :post
       end
+
+      def courses_interview_assessment_form_url(assessment)
+        if assessment.new_record?
+          admin_courses_season_interview_interview_assessments_path(current_season, interview)
+        else
+          admin_courses_season_interview_interview_assessment_path(current_season, interview, assessment)
+        end
+      end
+
+      def courses_interview_assessments_table(questions, interview)
+        return unless ::Courses::Interview::RatePolicy.new(interview).allowed?
+
+        render 'admin/courses/interview_assessments/table', questions: questions, interview: interview
+      end
+
+      def courses_interview_average_assessments(average_assessments)
+        return unless ::Courses::Interview::RatePolicy.new(interview).allowed?
+
+        render 'admin/courses/interview_assessments/average_marks', average_assessments: average_assessments
+      end
+
+      def courses_average_mark(hsh)
+        "#{hsh[:question]}: #{hsh[:mark]}"
+      end
     end
   end
 end

--- a/components/courses/app/models/courses/interview.rb
+++ b/components/courses/app/models/courses/interview.rb
@@ -7,6 +7,8 @@ module Courses
     belongs_to :mentor
     belongs_to :student, optional: true
 
+    has_many :interview_assessments
+
     enum status: %i[vacant pending completed missed]
 
     validates :start_at,   presence: true

--- a/components/courses/app/models/courses/interview_assessment.rb
+++ b/components/courses/app/models/courses/interview_assessment.rb
@@ -1,0 +1,13 @@
+module Courses
+  class InterviewAssessment < ApplicationRecord
+    self.table_name = 'courses_interview_assessments'
+
+    belongs_to :interview
+    belongs_to :mentor
+    belongs_to :question
+
+    RANGE = 1..5
+
+    validates :mark, inclusion: { in: RANGE }
+  end
+end

--- a/components/courses/app/policies/courses/interview/rate_policy.rb
+++ b/components/courses/app/policies/courses/interview/rate_policy.rb
@@ -1,0 +1,32 @@
+module Courses
+  class Interview < ApplicationRecord
+    class RatePolicy
+
+      def initialize(interview)
+        @interview = interview
+      end
+
+      def allowed?
+        interview_has_a_student? &&
+        interview_has_a_video_url? &&
+        interview_is_completed?
+      end
+
+      private
+
+      attr_reader :interview
+
+      def interview_has_a_student?
+        interview.student
+      end
+
+      def interview_has_a_video_url?
+        interview.video_url
+      end
+
+      def interview_is_completed?
+        interview.completed?
+      end
+    end
+  end
+end

--- a/components/courses/app/services/courses/interview/average_assessment.rb
+++ b/components/courses/app/services/courses/interview/average_assessment.rb
@@ -1,0 +1,41 @@
+module Courses
+  class Interview < ApplicationRecord
+    class AverageAssessment < ApplicationService
+      def initialize(interview, questions)
+        @interview = interview
+        @questions = questions
+      end
+
+      def call
+        @questions.map do |question|
+          question_params(question)
+        end
+      end
+
+      private
+
+      attr_reader :interview
+
+      def question_params(question)
+        { 
+          question: question.body,
+          mark:     question_average_mark(question)
+        }
+      end
+
+      def assessments
+        interview.interview_assessments
+      end
+
+      def question_average_mark(question)
+        marks = assessments.where(question_id: question).map(&:mark)
+        if marks.any?
+          ( marks.inject(:+).to_f / marks.size ).round(2)
+        else
+          0
+        end
+      end
+
+    end
+  end
+end

--- a/components/courses/app/views/admin/courses/interview_assessments/_average_marks.slim
+++ b/components/courses/app/views/admin/courses/interview_assessments/_average_marks.slim
@@ -1,0 +1,3 @@
+h3 = t 'courses.interviews.average_assessments'
+- average_assessments.each do |hsh|
+  p = courses_average_mark(hsh)

--- a/components/courses/app/views/admin/courses/interview_assessments/_form.slim
+++ b/components/courses/app/views/admin/courses/interview_assessments/_form.slim
@@ -1,0 +1,3 @@
+= simple_form_for assessment(interview, question), url: courses_interview_assessment_form_url(assessment(interview, question)), as: :interview_assessment do |f|
+  = f.input :question_id, as: :hidden, input_html: { value: question.id }
+  = f.input :mark, collection: ::Courses::InterviewAssessment::RANGE, checked: assessment(interview, question).mark, as: :radio_buttons, label: question.body, input_html: { onchange: "this.form.submit()" }

--- a/components/courses/app/views/admin/courses/interview_assessments/_table.slim
+++ b/components/courses/app/views/admin/courses/interview_assessments/_table.slim
@@ -1,0 +1,3 @@
+h4 = t 'courses.interview_assessments.rate'
+- questions.each do |question|
+  = render 'admin/courses/interview_assessments/form', interview: interview, question: question

--- a/components/courses/app/views/admin/courses/interviews/show.slim
+++ b/components/courses/app/views/admin/courses/interviews/show.slim
@@ -1,18 +1,27 @@
 = admin_courses_seasons_nav do
-  b = t 'courses.students.name'
-  p = interview.full_name
+  .ui.grid
+    .ten.wide.column
+      h3 = t 'courses.interviews.info'
+      b  = t 'courses.students.name'
+      p  = interview.full_name
 
-  b = t 'courses.mentors.name'
-  p = interview.mentor_name
+      b  = t 'courses.mentors.name'
+      p  = interview.mentor_name
 
-  b = t 'courses.interviews.start_at'
-  p = format_timestamp(interview.start_at)
+      b  = t 'courses.interviews.start_at'
+      p  = format_timestamp(interview.start_at)
 
-  b = t 'courses.interviews.status'
-  p = interview.status
+      b  = t 'courses.interviews.status'
+      p  = interview.status
 
-  b = t 'courses.interviews.description'
-  p = interview.description
+      b  = t 'courses.interviews.description'
+      p  = interview.description
 
-  b = t 'courses.interviews.video_url'
-  p = interview.video_url
+      b  = t 'courses.interviews.video_url'
+      p  = interview.video_url
+    .six.wide.column
+      = courses_interview_average_assessments(@average_assessment)
+  .ui.divider
+  .ui.grid
+    .eighteen.wide.column
+      = courses_interview_assessments_table(questions, interview)

--- a/components/courses/config/locales/en.courses.yml
+++ b/components/courses/config/locales/en.courses.yml
@@ -61,6 +61,11 @@ en:
       take: Take this time slot
       status: Status
       video_url: Video url
+      info: Interview Info
+      average_assessments: Average Assessments
+
+    interview_assessments:
+      rate: Please rate a student on a scale of 1-5
 
     lectures:
       plural: Lectures

--- a/components/courses/config/routes.rb
+++ b/components/courses/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       resources :seasons,      except: :destroy do
         resources :mentors,    except: %i[show edit update]
         resources :questions,  except: :destroy
-        resources :interviews, except: :destroy
+        resources :interviews, except: :destroy do
+          resources :interview_assessments, only: %i[create update]
+        end
         resources :students,   only:   :index
         resources :lectures,   except: :destroy
         resources :test_task,  only:   %i[index update]

--- a/components/courses/db/migrate/20170720151804_create_courses_interview_assessments.rb
+++ b/components/courses/db/migrate/20170720151804_create_courses_interview_assessments.rb
@@ -1,0 +1,14 @@
+class CreateCoursesInterviewAssessments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :courses_interview_assessments do |t|
+      t.integer :interview_id
+      t.integer :mentor_id
+      t.integer :question_id
+      t.integer :mark
+
+      t.timestamps
+    end
+
+    add_index :courses_interview_assessments, :interview_id
+  end
+end

--- a/components/courses/spec/dummy/db/schema.rb
+++ b/components/courses/spec/dummy/db/schema.rb
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(version: 20170721081343) do
     t.index ["student_id"], name: "index_courses_homeworks_on_student_id"
   end
 
+  create_table "courses_interview_assessments", force: :cascade do |t|
+    t.integer  "interview_id"
+    t.integer  "mentor_id"
+    t.integer  "question_id"
+    t.integer  "mark"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["interview_id"], name: "index_courses_interview_assessments_on_interview_id"
+  end
+
   create_table "courses_interviews", force: :cascade do |t|
     t.integer  "mentor_id"
     t.integer  "student_id"

--- a/components/courses/spec/policies/courses/interview/rate_policy_spec.rb
+++ b/components/courses/spec/policies/courses/interview/rate_policy_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Courses::Interview::RatePolicy do
+  let!(:season)      { create(:season, title: 'Test Season') }
+  let!(:student)     { create(:student) }
+  let!(:mentor)      { ::Courses::Mentor.create(user_id: 1, season_id: 1) }
+
+  describe '#allowed?' do
+    context 'has student, video url & is completed' do
+      let(:interview) { create(:interview, mentor_id: mentor.id, status: :completed, student_id: student.id, video_url: 'some url') }
+      let(:policy) { Courses::Interview::RatePolicy.new(interview) }
+
+      it 'allows to pass policy' do
+        expect(policy).to be_allowed
+      end
+    end
+  end
+
+  describe 'not allowed?' do
+    context 'interview has no student' do
+      let(:interview) { create(:interview, mentor_id: mentor.id, status: :completed, video_url: 'some url') }
+      let(:policy) { Courses::Interview::RatePolicy.new(interview) }
+
+      it 'allows to pass policy' do
+        expect(policy).not_to be_allowed
+      end
+    end
+
+    context 'interview has no video url' do
+      let(:interview) { create(:interview, mentor_id: mentor.id, status: :completed, student_id: student.id) }
+      let(:policy) { Courses::Interview::RatePolicy.new(interview) }
+
+      it 'allows to pass policy' do
+        expect(policy).not_to be_allowed
+      end
+    end
+
+    context 'interview is not completed' do
+      let(:interview) { create(:interview, mentor_id: mentor.id, status: :pending, student_id: student.id, video_url: 'some url') }
+      let(:policy) { Courses::Interview::RatePolicy.new(interview) }
+
+      it 'allows to pass policy' do
+        expect(policy).not_to be_allowed
+      end
+    end
+  end
+end

--- a/components/courses/spec/services/courses/interview/average_assessment_spec.rb
+++ b/components/courses/spec/services/courses/interview/average_assessment_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Courses::Interview::AverageAssessment do
+  let!(:season)            { create(:season, title: 'Test Season') }
+  let!(:first_mentor)      { ::Courses::Mentor.create(user_id: 1, season_id: season.id) }
+  let!(:second_mentor)     { ::Courses::Mentor.create(user_id: 1, season_id: season.id) }
+  let!(:interview)         { create(:interview, mentor_id: first_mentor.id, season_id: season.id) }
+  let!(:first_question)    { create(:question, season_id: season.id) }
+  let!(:second_question)   { create(:question, season_id: season.id) }
+  let!(:first_assessment)  { ::Courses::InterviewAssessment.create(interview_id: interview.id, mentor_id: first_mentor.id, question_id: first_question.id, mark: rand(::Courses::InterviewAssessment::RANGE))}
+  let!(:second_assessment) { ::Courses::InterviewAssessment.create(interview_id: interview.id, mentor_id: first_mentor.id, question_id: second_question.id, mark: rand(::Courses::InterviewAssessment::RANGE))}
+  let!(:third_assessment)  { ::Courses::InterviewAssessment.create(interview_id: interview.id, mentor_id: second_mentor.id, question_id: first_question.id, mark: rand(::Courses::InterviewAssessment::RANGE))}
+  let!(:fourth_assessment) { ::Courses::InterviewAssessment.create(interview_id: interview.id, mentor_id: second_mentor.id, question_id: second_question.id, mark: rand(::Courses::InterviewAssessment::RANGE))}
+
+  describe '#call' do
+    it 'calculates average assessment marks by question' do
+      questions = [first_question, second_question]
+
+      average_assessments = described_class.call(interview, questions)
+
+      average_mark_for_first_question = 
+        average_assessments.select{|hsh| hsh[:question] == first_question.body}.first[:mark]
+      average_mark_for_second_question = 
+        average_assessments.select{|hsh| hsh[:question] == second_question.body}.first[:mark]
+
+      expect(average_mark_for_first_question).to eq (first_assessment.mark+third_assessment.mark).to_f/2
+      expect(average_mark_for_second_question).to eq (second_assessment.mark+fourth_assessment.mark).to_f/2
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,16 @@ ActiveRecord::Schema.define(version: 20170721081343) do
     t.index ["student_id"], name: "index_courses_homeworks_on_student_id", using: :btree
   end
 
+  create_table "courses_interview_assessments", force: :cascade do |t|
+    t.integer  "interview_id"
+    t.integer  "mentor_id"
+    t.integer  "question_id"
+    t.integer  "mark"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["interview_id"], name: "index_courses_interview_assessments_on_interview_id", using: :btree
+  end
+
   create_table "courses_interviews", force: :cascade do |t|
     t.integer  "mentor_id"
     t.integer  "student_id"


### PR DESCRIPTION
Resolves #441

### Description

Every season mentor can evaluate a student by watching interview video and putting marks for each season question.

The interview should have a student, video url & be completed.

The average assessments table is shown on the interview view page.

### Screenshots
<img width="1278" alt="screenshot at jul 23 13-03-39" src="https://user-images.githubusercontent.com/12432979/28498493-66bb42fa-6fa7-11e7-8ddf-a92ddc70d3e5.png">