### PR TITLE
500 add speaker name to the talks

### DIFF
--- a/app/assets/stylesheets/app/pages/talks-archive/_talk.scss
+++ b/app/assets/stylesheets/app/pages/talks-archive/_talk.scss
@@ -51,6 +51,7 @@ $namespace: ".pk-archived-talk";
   #{$namespace}__event,
   #{$namespace}__data,
   #{$namespace}__title,
+  #{$namespace}__speaker,
   #{$namespace}__media__slides,
   #{$namespace}__media__video__link,
   #{$namespace}__media__video__duration {
@@ -240,4 +241,10 @@ $namespace: ".pk-archived-talk";
 
 #{$namespace}__centered {
   margin: auto
+}
+
+#{$namespace}__speaker {
+  font-family: "Arvo", serif;
+  margin-top: 6px;
+  font-size: 1rem;
 }

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -10,7 +10,7 @@ class TalksController < ApplicationController
   def talks
     @talks ||= search_against(Talk)
       .published
-      .includes(:event)
+      .includes(:event, :speaker)
       .page(params[:page])
       .sorted_by_date
   end

--- a/app/views/talks/index.slim
+++ b/app/views/talks/index.slim
@@ -13,6 +13,8 @@
         .pk-archived-talk__wrapper
           = talk_link talk, "", class: "pk-archived-talk__show"
           span.pk-archived-talk__data =  format_timestamp(talk.event.finished_at, time: false)
+          .pk-archived-talk__speaker
+            = talk.speaker.full_name
           h4.pk-archived-talk__title
             = talk_link talk, talk.title, class: "pk-link pk-archived-talk__link"
           / .pk-archived-talk__media

--- a/app/views/talks/index.slim
+++ b/app/views/talks/index.slim
@@ -14,7 +14,7 @@
           = talk_link talk, "", class: "pk-archived-talk__show"
           span.pk-archived-talk__data =  format_timestamp(talk.event.finished_at, time: false)
           .pk-archived-talk__speaker
-            = talk.speaker.full_name
+            = talk.speaker&.full_name
           h4.pk-archived-talk__title
             = talk_link talk, talk.title, class: "pk-link pk-archived-talk__link"
           / .pk-archived-talk__media

--- a/spec/features/talks/show_spec.rb
+++ b/spec/features/talks/show_spec.rb
@@ -1,9 +1,15 @@
 describe 'Talk SHOW' do
-  let(:talk)  { create :talk }
+  let(:user) { create :user, first_name: 'John', last_name: 'Doe' }
+  let(:talk) { create :talk, speaker_id: user.id }
 
   before { visit talk_path(talk) }
 
   it 'displays talk' do
     expect(page).to have_content talk.title
+  end
+
+  it 'shows talk speaker full name' do
+    expect(talk.speaker.full_name).to eq(user.full_name)
+    expect(page).to have_content talk.speaker.full_name
   end
 end


### PR DESCRIPTION
Resolves [github issue #500](https://github.com/pivorakmeetup/pivorak-web-app/issues/x)

### Description

Add speaker name to the `/talks` on each talk

### How to test instructions

Visit `http://localhost:3000/talks`
You should see full speaker name on each talk

### Pre-merge checklist
 
- [x] The PR relates to a single subject with a clear title and description
- [x] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| ![](https://image.prntscr.com/image/Yni7u_NFS76JYGlZ13TssQ.png) | ![](https://image.prntscr.com/image/qkNfFYrJQ-yeJNOzXP4-1A.png) |


