### PR TITLE
Homework can be sent multiple times

### DIFF
--- a/components/courses/app/controllers/courses/homeworks_controller.rb
+++ b/components/courses/app/controllers/courses/homeworks_controller.rb
@@ -23,7 +23,7 @@ module Courses
     end
 
     def lectures
-      @lectures ||=  current_season.lectures
+      @lectures ||=  Homework::AvailableLectures.call(current_season, current_student)
     end
 
     def homework_params

--- a/components/courses/app/finders/courses/homework/available_lectures.rb
+++ b/components/courses/app/finders/courses/homework/available_lectures.rb
@@ -1,0 +1,20 @@
+module Courses
+  class Homework < ApplicationRecord
+    class AvailableLectures < ApplicationFinder
+      def initialize(season, student)
+        @season = season
+        @student = student
+      end
+
+      def call
+        lectures_with_homeworks = season.lectures.includes(:homeworks)
+                                                 .where(courses_homeworks: { student_id: student.id } )
+        season.lectures - lectures_with_homeworks
+      end
+
+      private
+
+      attr_reader :season, :student
+    end
+  end
+end

--- a/components/courses/app/models/courses/lecture.rb
+++ b/components/courses/app/models/courses/lecture.rb
@@ -8,7 +8,8 @@ module Courses
     belongs_to :season
     belongs_to :venue
     belongs_to :mentor
-    has_many :progresses
+    has_many   :progresses
+    has_many   :homeworks
 
     UPCOMING = :upcoming
     PASSED   = :passed

--- a/components/courses/db/seeds.rb
+++ b/components/courses/db/seeds.rb
@@ -66,15 +66,15 @@ puts ::Courses::Interview.where(mentor_id: 1, student_id: 4).first_or_create!(
 
 #=== Interview Assessments ==============================================================
 
-5.times do |n|
-  puts ::Courses::InterviewAssessment.where(interview_id: 2, question_id: n + 1).first_or_create!(
-      mentor_id: 1, mark: rand(1..5)
-  )
-
-  puts ::Courses::InterviewAssessment.where(interview_id: 3, question_id: n + 1).first_or_create!(
-      mentor_id: 1, mark: rand(1..5)
-  )
-end
+# 5.times do |n|
+#   puts ::Courses::InterviewAssessment.where(interview_id: 2, question_id: n + 1).first_or_create!(
+#       mentor_id: 1, mark: rand(1..5)
+#   )
+#
+#   puts ::Courses::InterviewAssessment.where(interview_id: 3, question_id: n + 1).first_or_create!(
+#       mentor_id: 1, mark: rand(1..5)
+#   )
+# end
 
 #=== Lectures ===========================================================================
 

--- a/components/courses/spec/factories/homework_factory.rb
+++ b/components/courses/spec/factories/homework_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :homework, class: Courses::Homework do
+    git_url   'git'
+  end
+end

--- a/components/courses/spec/factories/mentor_factory.rb
+++ b/components/courses/spec/factories/mentor_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :mentor, class: Courses::Mentor do
+    user_id         { rand(0..100) }
+    season_id       { rand(0..6) }
+  end
+end

--- a/components/courses/spec/finders/courses/homework/available_lectures_spec.rb
+++ b/components/courses/spec/finders/courses/homework/available_lectures_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Courses::Homework::AvailableLectures do
+  let!(:season)          { create(:season) }
+  let!(:lecture)         { create(:lecture, venue_id: 1, season_id: season.id, mentor_id: 1) }
+  let!(:another_lecture) { create(:lecture, venue_id: 1, season_id: season.id, mentor_id: 1) }
+  let!(:student)         { create(:student, season_id: 1) }
+  let!(:homework)        { create(:homework, lecture_id: lecture.id, student_id: student.id)  }
+
+
+  describe '#call' do
+    it 'returns lectures without homeworks' do
+      query = described_class.call(season, student)
+
+      expect(query).to include(another_lecture)
+      expect(query).not_to include(lecture)
+    end
+  end
+end

--- a/components/courses/spec/finders/courses/lecture/mentors_for_lecture_spec.rb
+++ b/components/courses/spec/finders/courses/lecture/mentors_for_lecture_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Courses::Lecture::MentorsForLecture do
+  let!(:season)         { create(:season) }
+  let!(:mentor)         { create(:mentor, season_id: season.id) }
+  let!(:another_mentor) { create(:mentor, season_id: season.id) }
+
+  describe '#call' do
+    it 'returns all mentors for lecture' do
+      query = described_class.call(season)
+
+      expect(query).to include(mentor, another_mentor)
+    end
+  end
+end

--- a/components/courses/spec/finders/courses/mentor/available_for_mentoring_spec.rb
+++ b/components/courses/spec/finders/courses/mentor/available_for_mentoring_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Courses::Mentor::AvailableForMentoring do
+  let!(:season)       { create(:season) }
+  let!(:user)         { create(:user) }
+  let!(:another_user) { create(:user) }
+  let!(:mentor)       { create(:mentor, user_id: user.id, season_id: season.id) }
+
+  describe '#call' do
+    it 'returns available for mentoring users' do
+      query = described_class.call(season)
+
+      expect(query).to include(another_user)
+      expect(query).not_to include(user)
+    end
+  end
+end

--- a/components/courses/spec/finders/courses/season/all_for_current_mentor_spec.rb
+++ b/components/courses/spec/finders/courses/season/all_for_current_mentor_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Courses::Season::AllForCurrentMentor do
+  let!(:season)         { create(:season) }
+  let!(:another_season) { create(:season) }
+  let!(:user)           { create(:user) }
+  let!(:mentor)         { create(:mentor, user_id: user.id, season_id: season.id) }
+
+  describe '#call' do
+    it 'returns available for current mentor seasons' do
+      query = described_class.call(user)
+
+      expect(query).to include(season)
+      expect(query).not_to include(another_season)
+    end
+  end
+end


### PR DESCRIPTION
It doesn't appear on the progress page, but new records are added to the Courses::Homework table.  

Would be great to show user "You can't send this homework again!" error 


How to:

- Don't display lectures in the dropdown that has been already sent