### PR TITLE
Change visitors.pdf representation

### DIFF
--- a/app/services/pdf_reports/event_visitors_report.rb
+++ b/app/services/pdf_reports/event_visitors_report.rb
@@ -22,7 +22,7 @@ module PdfReports
 
     def formated_data
       @formated_data ||= visit_requests
-                         .map { |vr| vr.user.full_name }
+                         .map { |vr| vr.user.first_name.upcase }
                          .sort
                          .each_slice(settings.fetch(:columns, 1)).to_a
     end

--- a/spec/services/pdf_reports/event_visitors_report_spec.rb
+++ b/spec/services/pdf_reports/event_visitors_report_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PdfReports::EventVisitorsReport do
-  let(:first_user)  { create(:user, first_name: 'First', last_name: 'User') }
-  let(:second_user)  { create(:user, first_name: 'Second', last_name: 'User') }
-  let(:third_user)  { create(:user, first_name: 'Third', last_name: 'Long_user_last_name') }
+  let(:first_user)  { create(:user, first_name: 'Alex') }
+  let(:second_user)  { create(:user, first_name: 'Denys') }
+  let(:third_user)  { create(:user, first_name: 'Petro') }
   let!(:first_visit_request)  { create(:visit_request, user: first_user) }
   let!(:second_visit_request)  { create(:visit_request, user: second_user) }
   let!(:third_visit_request)  { create(:visit_request, user: third_user) }
@@ -14,19 +14,18 @@ RSpec.describe PdfReports::EventVisitorsReport do
 
   describe '.call' do
     context 'valid font styles' do
-      it { expect(text_inspector.font_settings.first[:name]).to eq settings[:font] }
-      it { expect(text_inspector.font_settings.first[:size]).to eq settings.dig(:table, :cell_style, :size) }
+      it { expect(text_inspector.font_settings.first[:name]).to eq :Courier }
+      it { expect(text_inspector.font_settings.first[:size]).to eq 21 }
     end
 
     context 'valid text' do
-      it { expect(text_inspector.strings.first).to eq first_user.full_name }
-      it { expect(text_inspector.strings.last).to eq third_user.last_name }
-      it { expect(text_inspector.strings.size).to eq 4 }
+      it { expect(text_inspector.strings.to_a).to eq(['ALEX', 'DENYS', 'PETRO']) }
+      it { expect(text_inspector.strings.size).to eq 3 }
     end
 
     context 'valid pages' do
-      it { expect(page_inspector.pages.first[:strings]).to include(first_user.full_name) }
-      it { expect(page_inspector.pages.second[:strings]).to contain_exactly(third_user.first_name, third_user.last_name) }
+      it { expect(page_inspector.pages.first[:strings]).to include('DENYS') }
+      it { expect(page_inspector.pages.second[:strings]).to include('PETRO') }
       it { expect(page_inspector.pages.size).to eq 2 }
     end
   end


### PR DESCRIPTION
### Description

On the event it is not fun to write names by hand.
I suggest to print everybody names on the paper.
PDF should contain only first names in uppercase.

This PR will change visitors.pdf

### How to test instructions

- Visit http://localhost:3000/admin/events/pivorak-26-coming-soon/visit_requests/report

  or

- Visit http://localhost:3000/admin/events
- Click "settings" icon
- Click Visitors Report

### How report will look like
[Uploading event_visitors_report20180526-65489-n6fj8a.pdf…]()
