### PR TITLE
Change 'homework_mark' column type to decimal in 'courses_progress'

### DIFF
--- a/db/migrate/20180707183058_change_homework_mark_in_courses_progress.rb
+++ b/db/migrate/20180707183058_change_homework_mark_in_courses_progress.rb
@@ -1,0 +1,5 @@
+class ChangeHomeworkMarkInCoursesProgress < ActiveRecord::Migration[5.2]
+  def change
+    change_column :courses_progress, :homework_mark, :decimal, precision: 4, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_17_193509) do
+ActiveRecord::Schema.define(version: 2018_07_07_183058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2018_06_17_193509) do
     t.integer "student_id"
     t.integer "lecture_id"
     t.integer "mentor_id"
-    t.float "homework_mark"
+    t.decimal "homework_mark", precision: 4, scale: 2
     t.integer "lecture_presence", default: 0
     t.index ["lecture_id"], name: "index_courses_progress_on_lecture_id"
     t.index ["mentor_id"], name: "index_courses_progress_on_mentor_id"


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/x)

### Description

Change 'homework_mark' column type to decimal(with precision 4 and scale 2) in 'courses_progress' for better calculation of student's total mark.

### How to test instructions

Add to integer some float mark, after subtract float number. With decimal type you'll see expected result, if type is float the result is unexpected.

### Pre-merge checklist
 
- [ ] The PR relates to a single subject with a clear title and description
- [ ] Verify that feature branch is up-to-date with `development` (if not - rebase it). 

### Screenshots

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| ![screenshot from 2018-07-08 00-04-30](https://user-images.githubusercontent.com/27735570/42414675-b959f0fc-8242-11e8-8c6c-2d126301f7f6.png) | ![screenshot from 2018-07-08 00-01-45](https://user-images.githubusercontent.com/27735570/42414678-d7a9f8ae-8242-11e8-8c33-3f4631137fca.png) |


