### PR TITLE
Fix factory bot warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,12 +96,6 @@ Lint/HandleExceptions:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions'
   Enabled: true
 
-Lint/InvalidCharacterLiteral:
-  Description: >-
-                 Checks for invalid character literals with a non-escaped
-                 whitespace character.
-  Enabled: true
-
 Lint/LiteralInCondition:
   Description: 'Checks of literals used in conditions.'
   Enabled: true
@@ -818,7 +812,7 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Description: 'When defining binary operators, name the argument other.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
   Enabled: false
@@ -1084,11 +1078,6 @@ Layout/TrailingBlankLines:
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in parameter lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
-  Enabled: false
-
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: false
 
 Layout/TrailingWhitespace:

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ end
 group :development, :test do
   gem 'rspec'
   gem 'rubocop',                                    '~> 0.59.2', require: false
+  gem 'rubocop-rspec'
   gem 'rspec-rails'
   gem 'pry-rails'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,6 +478,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.30.0)
+      rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
@@ -666,6 +668,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rubocop (~> 0.59.2)
+  rubocop-rspec
   sass-rails (~> 5.0)
   semantic-ui-sass (~> 2.2)
   shoulda-matchers
@@ -695,4 +698,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/components/courses/spec/factories/homework_factory.rb
+++ b/components/courses/spec/factories/homework_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :homework, class: Courses::Homework do
-    git_url 'git'
+    git_url { 'git' }
   end
 end

--- a/components/courses/spec/factories/user_factory.rb
+++ b/components/courses/spec/factories/user_factory.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :user do
-    first_name 'Test'
-    last_name 'User'
-    email 'example@user.com'
-    admin true
+    first_name { 'Test' }
+    last_name { 'User' }
+    email { 'example@user.com' }
+    admin { true }
   end
 end

--- a/components/courses/spec/factories/venues_factory.rb
+++ b/components/courses/spec/factories/venues_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :venue do
     name { Faker::GameOfThrones.city }
-    address 'Westeros'
+    address { 'Westeros' }
   end
 end

--- a/spec/factories/donation_factory.rb
+++ b/spec/factories/donation_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :donation do
-    amount     Faker::Number.decimal(3, 2)
+    amount     { Faker::Number.decimal(3, 2) }
     payment_id { Faker::Number.number(6) }
 
     trait :assigned do

--- a/spec/factories/email_factory.rb
+++ b/spec/factories/email_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :email do
     add_attribute :subject, Faker::Lorem.word
-    body Faker::Lorem.paragraph
+    body { Faker::Lorem.paragraph }
   end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :event do
-    title       Faker::Lorem.word
-    agenda      Faker::Lorem.paragraph
-    status      Event::REGISTRATION
-    published   true
-    started_at  Time.now
-    finished_at Time.now
+    title       { Faker::Lorem.word }
+    agenda      { Faker::Lorem.paragraph }
+    status      { Event::REGISTRATION }
+    published   { true }
+    started_at  { Time.now }
+    finished_at { Time.now }
   end
 end

--- a/spec/factories/friend_factory.rb
+++ b/spec/factories/friend_factory.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :friend do
-    name        Faker::Name.name
-    description Faker::Lorem.paragraph
-    link        Faker::Internet.url
-    logo        File.open(Rails.root + 'spec/fixtures/images/pivorak.png')
+    name        { Faker::Name.name }
+    description { Faker::Lorem.paragraph }
+    link        { Faker::Internet.url }
+    logo        { File.open(Rails.root + 'spec/fixtures/images/pivorak.png') }
 
     trait :published do
-      published true
+      published { true }
     end
   end
 end

--- a/spec/factories/goal_factory.rb
+++ b/spec/factories/goal_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :goal do
-    title       Faker::Lorem.word
-    description Faker::Lorem.paragraph
-    amount      Faker::Number.decimal(3, 2)
+    title       { Faker::Lorem.word }
+    description { Faker::Lorem.paragraph }
+    amount      { Faker::Number.decimal(3, 2) }
   end
 
   trait :with_donations do

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :group do
-    name     Faker::Lorem.word
-    resource 'Talk'
+    name     { Faker::Lorem.word }
+    resource { 'Talk' }
   end
 end

--- a/spec/factories/identity_factory.rb
+++ b/spec/factories/identity_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :identity do
-    provider Devise.omniauth_providers.sample
-    uid      Faker::Number.number(16)
+    provider { Devise.omniauth_providers.sample }
+    uid      { Faker::Number.number(16) }
   end
 end

--- a/spec/factories/omniauth_factory.rb
+++ b/spec/factories/omniauth_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :omniauth_params, class: Hash do
-    provider Devise.omniauth_providers.sample
-    uid      Faker::Number.number(16)
+    provider { Devise.omniauth_providers.sample }
+    uid      { Faker::Number.number(16) }
     info {
       {
         email:      Faker::Internet.email,
@@ -18,8 +18,8 @@ FactoryBot.define do
   end
 
   factory :twitter_params, class: Hash do
-    provider 'twitter'
-    uid      Faker::Number.number(16)
+    provider { 'twitter' }
+    uid      { Faker::Number.number(16) }
     info {
       {
         email: Faker::Internet.email,
@@ -31,8 +31,8 @@ FactoryBot.define do
   end
 
   factory :facebook_params, class: Hash do
-    provider 'facebook'
-    uid      Faker::Number.number(16)
+    provider { 'facebook' }
+    uid      { Faker::Number.number(16) }
     info { {
       email: Faker::Internet.email,
       name:  Faker::Name.name
@@ -42,8 +42,8 @@ FactoryBot.define do
   end
 
   factory :github_params, class: Hash do
-    provider 'github'
-    uid      Faker::Number.number(16)
+    provider { 'github' }
+    uid      { Faker::Number.number(16) }
     info { {
       email: Faker::Internet.email,
       name:  Faker::Name.name

--- a/spec/factories/page_factory.rb
+++ b/spec/factories/page_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :page do
-    title Faker::Lorem.word
+    title { Faker::Lorem.word }
     sequence(:url) { |n| "page-#{n}" }
-    body Faker::Lorem.paragraph
+    body { Faker::Lorem.paragraph }
   end
 end

--- a/spec/factories/stripe_factory.rb
+++ b/spec/factories/stripe_factory.rb
@@ -1,22 +1,22 @@
 FactoryBot.define do
   factory :valid_credit_card, class: Hash do
-    number     '42' *  8
-    exp_month  Faker::Number.between(1, 12)
-    exp_year   Time.now.year.next.to_s
-    cvc        Faker::Number.number(3)
+    number     { '42' *  8 }
+    exp_month  { Faker::Number.between(1, 12) }
+    exp_year   { Time.now.year.next.to_s }
+    cvc        { Faker::Number.number(3) }
 
     initialize_with { attributes }
   end
 
   factory :valid_customer, class: Hash do
-    email Faker::Internet.email
+    email { Faker::Internet.email }
 
     initialize_with { attributes }
   end
 
   factory :valid_charge, class: Hash do
-    amount      Faker::Number.number(3)
-    description Faker::Lorem.paragraph
+    amount      { Faker::Number.number(3) }
+    description { Faker::Lorem.paragraph }
 
     initialize_with { attributes }
   end

--- a/spec/factories/talk_factory.rb
+++ b/spec/factories/talk_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :talk do
-    title       Faker::Lorem.word
-    description Faker::Lorem.paragraph
-    video_url   Faker::Internet.url('youtube.com')
-    slides_url  Faker::Internet.url('slideshare.net')
-    published   true
+    title       { Faker::Lorem.word }
+    description { Faker::Lorem.paragraph }
+    video_url   { Faker::Internet.url('youtube.com') }
+    slides_url  { Faker::Internet.url('slideshare.net') }
+    published   { true }
   end
 
   trait :assigned do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -3,33 +3,33 @@ FactoryBot.define do
     sequence(:first_name) { |n| "#{Faker::Name.first_name}#{n}" }
     sequence(:last_name) { |n| "#{Faker::Name.last_name}#{n}" }
     sequence(:email) { |n| "pivorak.member#{n}@example.com" }
-    password         Faker::Internet.password(20)
-    confirmed_at     Time.zone.now
+    password         { Faker::Internet.password(20) }
+    confirmed_at     { Time.zone.now }
 
     trait :admin do
-      admin true
+      admin { true }
     end
 
     trait :supervisor do
-      admin      true
-      supervisor true
+      admin      { true }
+      supervisor { true }
     end
 
     trait :verified do
-      verified true
+      verified { true }
     end
 
     trait :tester do
-      email      'tester@example.com'
-      first_name 'Tester'
-      last_name  'User'
+      email      { 'tester@example.com' }
+      first_name { 'Tester' }
+      last_name  { 'User' }
     end
 
     trait :synth do
-      email      'synth@example.com'
-      first_name 'Synth'
-      last_name  'User'
-      synthetic  true
+      email      { 'synth@example.com' }
+      first_name { 'Synth' }
+      last_name  { 'User' }
+      synthetic  { true }
     end
   end
 end

--- a/spec/factories/venue_factory.rb
+++ b/spec/factories/venue_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :venue do
-    name  Faker::Lorem.word
-    address Faker::Address.street_address
-    map_url Faker::Internet.url
+    name  { Faker::Lorem.word }
+    address { Faker::Address.street_address }
+    map_url { Faker::Internet.url }
   end
 end

--- a/spec/factories/visit_request_factory.rb
+++ b/spec/factories/visit_request_factory.rb
@@ -2,36 +2,36 @@ FactoryBot.define do
   factory :visit_request do
     event
     user
-    status VisitRequest::PENDING
+    status { VisitRequest::PENDING }
 
     trait :final do
-      status VisitRequest::APPROVED
+      status { VisitRequest::APPROVED }
       visited { true }
     end
 
     trait :visited do
-      visited true
-      checked_in_at Time.zone.now
+      visited { true }
+      checked_in_at { Time.zone.now }
     end
 
     trait :pending do
-      status VisitRequest::PENDING
+      status { VisitRequest::PENDING }
     end
 
     trait :approved do
-      status VisitRequest::APPROVED
+      status { VisitRequest::APPROVED }
     end
 
     trait :refused do
-      status VisitRequest::REFUSED
+      status { VisitRequest::REFUSED }
     end
 
     trait :canceled do
-      status VisitRequest::CANCELED
+      status { VisitRequest::CANCELED }
     end
 
     trait :confirmed do
-      status VisitRequest::CONFIRMED
+      status { VisitRequest::CONFIRMED }
     end
   end
 end


### PR DESCRIPTION
### Description

Fixes warnings in console:
```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

status { :canceled }
```

### How to test instructions

- run specs on `development`
- run specs on `fix-factory-bot-warnings`
