### PR TITLE
Add confirmation email

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,7 @@ SimpleCov.profiles.define 'pivorak_cov' do
   add_filter '/config/'
   add_filter '/lib/tasks'
   add_filter '/components'
+  add_filter '/app/mailer_previews'
 
   add_group 'Controllers', 'app/controllers'
   add_group 'Models',      'app/models'

--- a/app/controllers/admin/visit_request/send_confirmation_reminders_controller.rb
+++ b/app/controllers/admin/visit_request/send_confirmation_reminders_controller.rb
@@ -1,0 +1,11 @@
+module Admin
+  class VisitRequest
+    class SendConfirmationRemindersController < VisitRequest::BaseController
+      def create
+        Event::SendConfirmationReminders.call(event)
+
+        default_redirect
+      end
+    end
+  end
+end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -67,5 +67,14 @@ module Admin
         method: :post, class: 'ui button red',
         data: { confirm: t('phrases.confirm') }
     end
+
+    def send_confirmation_reminders_emails_link(event)
+      return unless event.confirmation?
+
+      link_to t('events.send_confirmation_reminders'),
+        send_confirmation_reminders_admin_event_visit_requests_path(event),
+        method: :post, class: 'ui button blue',
+        data: { confirm: t('phrases.confirm') }
+    end
   end
 end

--- a/app/mailer_previews/visit_request_mailer_preview.rb
+++ b/app/mailer_previews/visit_request_mailer_preview.rb
@@ -8,6 +8,11 @@ class VisitRequestMailerPreview
     Premailer::Rails::Hook.perform(mail)
   end
 
+  def confirmation_reminder
+    mail = VisitRequestMailer.confirmation_reminder visit_request
+    Premailer::Rails::Hook.perform(mail)
+  end
+
   def needs_confirmation
     VisitRequestMailer.needs_confirmation visit_request
   end

--- a/app/mailers/visit_request_mailer.rb
+++ b/app/mailers/visit_request_mailer.rb
@@ -24,6 +24,16 @@ class VisitRequestMailer < ApplicationMailer
     mail(subject: "Final #pivorak details! | #{@event.title}", to: @user.email)
   end
 
+  def confirmation_reminder(visit_request)
+    @visit_request     = visit_request
+    @event             = @visit_request.event
+    @user              = @visit_request.user
+    @confirm_visit_url = event_visit_request_url(@event, @visit_request, answer: :yes, token: @visit_request.token, host: host)
+    @cancel_visit_url  = event_visit_request_url(@event, @visit_request, answer: :no, token: @visit_request.token, host: host)
+
+    mail(subject: "Confirmation reminder | #{@event.title}", to: @user.email)
+  end
+
   def needs_confirmation(visit_request)
     @visit_request = visit_request
     @event         = @visit_request.event

--- a/app/services/event/send_confirmation_reminders.rb
+++ b/app/services/event/send_confirmation_reminders.rb
@@ -1,0 +1,17 @@
+class Event
+  class SendConfirmationReminders < ApplicationService
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      event.visit_requests.approved.each do |visit_request|
+        VisitRequestMailer.confirmation_reminder(visit_request).deliver_later
+      end
+    end
+
+    private
+
+    attr_reader :event
+  end
+end

--- a/app/views/admin/events/form.slim
+++ b/app/views/admin/events/form.slim
@@ -10,6 +10,7 @@
       = admin_back_link(:events)
       = preview_link(event)
       = send_confirmation_emails_link(event)
+      = send_confirmation_reminders_emails_link(event)
       = admin_visit_requests_link(event, class: 'ui teal button')
       = f.button :submit
 

--- a/app/views/mailers/visit_request_mailer/confirmation_reminder.slim
+++ b/app/views/mailers/visit_request_mailer/confirmation_reminder.slim
@@ -1,0 +1,22 @@
+p Hello, #{@user.full_name}!
+
+p
+  | Are you planning to visit #Pivorak Conference  tomorrow?
+  br This time we are sending a QR Code which will be your ticket to the world of crawfishes and Ruby.
+  br We have a limited amount of available places, so if you cannot join - please, let us know.
+  br You will make someone from a waiting list extremely happy!
+
+p
+  b Sure!
+  '
+  = link_to 'YES', @confirm_visit_url, class: 'btn green'
+
+p
+  b Sorry, I won't come
+  '
+  = link_to 'NO', @cancel_visit_url, class: 'btn red'
+
+p
+  | Thanks and see you soon!
+  br Regards,
+  br #pivorak Team

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     visitors: Visitors
     attendees: Attendees
     send_confirmations: Send Confirmations
+    send_confirmation_reminders: Send Confirmation Reminders
     visitors_report: Visitors Report
     free_places: Open Places Left
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       resources :visit_requests, only: %i[index] do
         collection do
           post :send_confirmations, to: 'visit_request/send_confirmations#create'
+          post :send_confirmation_reminders, to: 'visit_request/send_confirmation_reminders#create'
           post :import,             to: 'visit_request/import#create'
           get  :report,             to: 'visit_request/report#download'
         end

--- a/spec/factories/email_factory.rb
+++ b/spec/factories/email_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :email do
-    add_attribute :subject, Faker::Lorem.word
+    subject { Faker::Lorem.word }
     body { Faker::Lorem.paragraph }
   end
 end

--- a/spec/features/admin/events/send_confirmations_spec.rb
+++ b/spec/features/admin/events/send_confirmations_spec.rb
@@ -9,10 +9,17 @@ RSpec.describe 'Events SEND CONFIRMATIONS' do
 
   it { expect(page).to have_link 'Send Confirmations' }
 
-  context 'send emails' do
+  describe 'Send Confirmations' do
     after { click_link 'Send Confirmations' }
 
     it { expect(Event::SendConfirmations).to receive(:call).with(event) }
     it { expect(VisitRequestMailer).to receive_message_chain(:confirmation, :deliver_later) }
+  end
+
+  describe 'Send Confirmation Reminders' do
+    after { click_link 'Send Confirmation Reminders' }
+
+    it { expect(Event::SendConfirmationReminders).to receive(:call).with(event) }
+    it { expect(VisitRequestMailer).to receive_message_chain(:confirmation_reminder, :deliver_later) }
   end
 end

--- a/spec/mailers/visit_request_mailer_spec.rb
+++ b/spec/mailers/visit_request_mailer_spec.rb
@@ -62,6 +62,22 @@ describe VisitRequestMailer do
     end
   end
 
+  describe '#confirmation_reminder' do
+    let(:mail) { described_class.confirmation_reminder(visit_request) }
+    let(:event) { create(:event, venue: create(:venue)) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq("Confirmation reminder | #{event.title}")
+      expect(mail.to).to eq([visit_request.user.email])
+      expect(mail.from).to eq([ApplicationMailer::PIVORAK_EMAIL])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to include event.title
+      expect(mail.body.encoded).to include user.full_name
+    end
+  end
+
   describe '#attendance_confirmed' do
     let(:mail) { described_class.attendance_confirmed(visit_request.reload) }
     let(:event) { create(:event, venue: venue) }

--- a/spec/services/event/send_confirmation_reminders_spec.rb
+++ b/spec/services/event/send_confirmation_reminders_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Event::SendConfirmationReminders do
+  subject(:service) { described_class.new(event) }
+  let(:event) { create(:event) }
+
+  describe '#call' do
+    subject(:call) { service.call }
+
+    let!(:approved_request) { create(:visit_request, :approved, event: event) }
+    let(:last_job) { active_jobs.last }
+    before do
+      create(:visit_request, :confirmed, event: event)
+      create(:visit_request, :refused, event: event)
+      create(:visit_request, :approved)
+    end
+
+    it 'sends confirmation reminders to people who did not confirm their attendance' do
+      allow(VisitRequestMailer).to receive(:confirmation_reminder).with(approved_request).and_call_original
+
+      call
+
+      expect(VisitRequestMailer).to have_received(:confirmation_reminder).once
+
+      expect(active_jobs.size).to eq(1)
+      expect(last_job[:job]).to eq ActionMailer::DeliveryJob
+      expect(last_job[:args][0]).to eq 'VisitRequestMailer'
+      expect(last_job[:args][1]).to eq 'confirmation_reminder'
+    end
+  end
+end


### PR DESCRIPTION
We should remind people who did not confirm or cancel their attendance.
This email will be send manually for now.
It will be send for all people with visit request approved.
Also, we can send it automatically one day before the event.

### How to test instructions

- Visit http://localhost:3000/emails/en/visit_request_mailer_preview-confirmation_reminder
- Visit http://localhost:3000/admin/events/pivorak-conference/edit to see `Send confirmation Reminders` button

### Screenshots
![img](https://duaw26jehqd4r.cloudfront.net/items/0f0t3K0b0x2f471h1L1d/%5B60bd3e29bacf422730af62ccbfc7c996%5D_Image%25202018-10-25%2520at%252011.46.11%2520AM.png?v=85258287)
