### PR TITLE
Add agenda page link

### DIFF
--- a/app/assets/stylesheets/app/application.scss
+++ b/app/assets/stylesheets/app/application.scss
@@ -53,6 +53,8 @@
 
 @import "pages/donate/form";
 
+@import "pages/agenda/agenda";
+
 @import "shared/list";
 @import "shared/search";
 @import "shared/talk";

--- a/app/assets/stylesheets/app/pages/agenda/_agenda.scss
+++ b/app/assets/stylesheets/app/pages/agenda/_agenda.scss
@@ -1,0 +1,10 @@
+$mobile-breakpoint: "420";
+
+.pk-agenda-container {
+  font-size: 3vw;
+  padding: 20px 32px;
+
+  @include breakpoint-max($mobile-breakpoint) {
+    padding: 20px 16px;
+  }
+}

--- a/app/controllers/agenda_controller.rb
+++ b/app/controllers/agenda_controller.rb
@@ -1,0 +1,15 @@
+class AgendaController < ApplicationController
+  helper_method :agenda
+
+  def show; end
+
+  private
+
+  def event
+    @event ||= Event.current.first!
+  end
+
+  def agenda
+    MarkdownRenderer.call(event.agenda)
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -46,4 +46,10 @@ module NavigationHelper
   def admin_link
     link_to t('admin.admin'), admin_path
   end
+
+  def agenda_link
+    return unless Event.current.exists?
+
+    link_to "agenda", agenda_path
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,6 +29,7 @@ class Event < ApplicationRecord
   has_many :newbie_visitors,   -> { merge(User.newbies) },  through: :visit_requests, source: :user
 
   scope :display, -> { where.not(status: PLANNED) }
+  scope :current, -> { where('started_at >= :beginning_of_day AND finished_at < :end_of_day', beginning_of_day: Time.now.beginning_of_day, end_of_day: Time.now.end_of_day) }
 
   validates :title, :limit_total, :limit_verified, presence: true
   validates_with LimitsValidator

--- a/app/views/agenda/show.slim
+++ b/app/views/agenda/show.slim
@@ -1,0 +1,4 @@
+= content_for :main_body_class, "pk-body--green-bg"
+
+.pk-agenda-container
+  == agenda

--- a/app/views/layouts/app/_header.slim
+++ b/app/views/layouts/app/_header.slim
@@ -61,7 +61,8 @@ header.pk-header class="#{yield(:main_header_class)}"
               /    li.pk-header__li-list-item = members_link
               /    li.pk-header__li-list-item = speakers_link
 
-              /li.pk-list__unit = goals_link
+              li.pk-list__unit
+                = agenda_link
 
               li.pk-list__unit
                 = link_to "friends", supporters_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   end
 
   resource :supporters, only: %i[show]
+  resource :agenda, only: %i[show], controller: :agenda
 
   #=== ADMIN AREA ===============================
   namespace :admin do

--- a/spec/features/agenda/read_spec.rb
+++ b/spec/features/agenda/read_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'Agenda page' do
+  subject { page }
+
+  context 'when upcoming event exist' do
+    it 'shows event agenda' do
+      create(:event, status: :confirmation, started_at: 1.month.ago)
+      event = create(:event, status: :confirmation, agenda: 'agenda text', started_at: Time.zone.now, finished_at: 1.hour.from_now)
+
+      visit "/agenda"
+
+      expect(page).to have_content(event.agenda)
+    end
+  end
+
+  context 'when no upcoming event exist' do
+    it 'returns 404' do
+      create(:event, status: :confirmation, started_at: 2.days.ago, finished_at: 1.day.ago)
+
+      visit "/agenda"
+
+      expect(page).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
### Description

Add ongoing event agenda page.
It will be accessible via header menu.
If there are no ongoing event - link will not be visible, page is not accessible.

### How to test instructions

- Visit http://localhost:3000/agenda

### Screenshots

<img width="1280" alt="captura de pantalla 2018-10-26 a las 9 59 10 a m" src="https://user-images.githubusercontent.com/5591973/47549834-f992a000-d905-11e8-9b12-cb99f91216cb.png">