### PR TITLE
Stub Slack Client instead of VCR

### DIFF
--- a/spec/cassettes/Slack_Invite/_call/when_invited_second_time/1_1_2_1.yml
+++ b/spec/cassettes/Slack_Invite/_call/when_invited_second_time/1_1_2_1.yml
@@ -2,71 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://slack.com/api/users.admin.invite?email=new-user@mail.com&token=xoxp-44605439956-44567237715-46971387168-841927fece
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.8.2.4, ruby 2.3.1 (2016-04-26))
-      Accept:
-      - "*/*"
-      Date:
-      - Thu, 01 Dec 2016 20:57:33 GMT
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '38'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Date:
-      - Thu, 01 Dec 2016 20:57:33 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - client
-      X-Content-Type-Options:
-      - nosniff
-      X-Oauth-Scopes:
-      - identify,read,post,client,apps,admin
-      X-Slack-Backend:
-      - h
-      X-Slack-Req-Id:
-      - f6f13bb5-44b3-4580-99ea-34da8a6f252d
-      X-Xss-Protection:
-      - '0'
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 c0486ca54d4ad5a3da496bc2b5f49cd2.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - HxBh7TocECkpLWmTAMHg8hOzVoJrkz2Tq9rop5h396LO9fWrW7YYeQ==
-    body:
-      encoding: UTF-8
-      string: '{"ok":false,"error":"already_invited"}'
-    http_version: 
-  recorded_at: Thu, 01 Dec 2016 20:57:34 GMT
-- request:
-    method: get
     uri: https://slack.com/api/users.admin.invite?email=new-user@mail.com&resend=true&token=xoxp-44605439956-44567237715-46971387168-841927fece
     body:
       encoding: UTF-8
@@ -77,7 +12,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 02 Dec 2016 08:42:07 GMT
+      - Tue, 20 Nov 2018 07:50:54 GMT
   response:
     status:
       code: 200
@@ -85,49 +20,45 @@ http_interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '36'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Content-Security-Policy:
-      - referrer no-referrer;
       Date:
-      - Fri, 02 Dec 2016 08:42:08 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
+      - Tue, 20 Nov 2018 07:50:54 GMT
       Server:
       - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Vary:
       - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - client
-      X-Content-Type-Options:
-      - nosniff
-      X-Oauth-Scopes:
-      - identify,read,post,client,apps,admin
+      X-Slack-Exp:
+      - '1'
       X-Slack-Backend:
       - h
+      X-Slack-Router:
+      - p
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       X-Slack-Req-Id:
-      - 917e65ca-9d67-47cb-9007-f66a839f82a5
+      - de89a15b-6963-49f9-a56a-bebb73bc7065
       X-Xss-Protection:
       - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Via:
+      - haproxy-www-wyuf
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 91db3e27f70759a0dea967c4b34efea9.cloudfront.net (CloudFront)
+      - 1.1 61a9e59c5096de6d5aa2d30643685276.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - DoGPRpKGp4aHIYCWbhv_7NgI0q1VyE8oBnbyY7aXGKckkqDkhyE0Pg==
+      - npuAHP99nO6avqRpX5rLuRYTBjsyzO1m2QuEXEVjLo-SLXT14wpX_g==
     body:
       encoding: UTF-8
-      string: '{"ok":false,"error":"sent_recently"}'
+      string: '{"ok":false,"error":"token_revoked"}'
     http_version: 
-  recorded_at: Fri, 02 Dec 2016 08:42:08 GMT
+  recorded_at: Tue, 20 Nov 2018 07:50:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/Slack_Invite/_call/when_success/1_1_1_1.yml
+++ b/spec/cassettes/Slack_Invite/_call/when_success/1_1_1_1.yml
@@ -2,71 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://slack.com/api/users.admin.invite?email=new-user@mail.com&token=xoxp-44605439956-44567237715-46971387168-841927fece
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - HTTPClient/1.0 (2.8.2.4, ruby 2.3.1 (2016-04-26))
-      Accept:
-      - "*/*"
-      Date:
-      - Thu, 01 Dec 2016 20:57:33 GMT
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '11'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Content-Security-Policy:
-      - referrer no-referrer;
-      Date:
-      - Thu, 01 Dec 2016 20:57:33 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - client
-      X-Content-Type-Options:
-      - nosniff
-      X-Oauth-Scopes:
-      - identify,read,post,client,apps,admin
-      X-Slack-Backend:
-      - h
-      X-Slack-Req-Id:
-      - 22a0bf4c-e237-4053-87a4-28b67e30657b
-      X-Xss-Protection:
-      - '0'
-      X-Cache:
-      - Miss from cloudfront
-      Via:
-      - 1.1 bc9bd2c59aa48e2932432099ba36a25b.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - BdUEQKP3VpKVhcrwQ5vmtUnnoMaPkPxtB5Eovi0oshWkvLoxfV5WrA==
-    body:
-      encoding: UTF-8
-      string: '{"ok":true}'
-    http_version: 
-  recorded_at: Thu, 01 Dec 2016 20:57:33 GMT
-- request:
-    method: get
     uri: https://slack.com/api/users.admin.invite?email=new-user@mail.com&resend=true&token=xoxp-44605439956-44567237715-46971387168-841927fece
     body:
       encoding: UTF-8
@@ -77,7 +12,7 @@ http_interactions:
       Accept:
       - "*/*"
       Date:
-      - Fri, 02 Dec 2016 08:42:05 GMT
+      - Tue, 20 Nov 2018 07:50:54 GMT
   response:
     status:
       code: 200
@@ -85,49 +20,45 @@ http_interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '11'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Content-Security-Policy:
-      - referrer no-referrer;
       Date:
-      - Fri, 02 Dec 2016 08:42:06 GMT
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Pragma:
-      - no-cache
+      - Tue, 20 Nov 2018 07:50:54 GMT
       Server:
       - Apache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Vary:
       - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - client
-      X-Content-Type-Options:
-      - nosniff
-      X-Oauth-Scopes:
-      - identify,read,post,client,apps,admin
+      X-Slack-Exp:
+      - '1'
       X-Slack-Backend:
       - h
+      X-Slack-Router:
+      - p
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       X-Slack-Req-Id:
-      - bc4e5571-d8f4-457d-b973-8a682b390d8e
+      - af650672-1dde-4270-8ce5-c72bfabf0158
       X-Xss-Protection:
       - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Via:
+      - haproxy-www-wwh4
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 0e417d376ffbd42061f20338431828b5.cloudfront.net (CloudFront)
+      - 1.1 e0bff21aaebc112bfc39331bbb2a57d0.cloudfront.net (CloudFront)
       X-Amz-Cf-Id:
-      - yLF4QMnFcOiFnkYb_qOLjhKLP5wxYDTXJl9OSKYnbo6jv8l6lB-esQ==
+      - EhWDcB-jdY_oQiiklnQRhkLj0LHOwYWHF1vS1W74goW03L2wgZgFvQ==
     body:
       encoding: UTF-8
-      string: '{"ok":true}'
+      string: '{"ok":false,"error":"token_revoked"}'
     http_version: 
-  recorded_at: Fri, 02 Dec 2016 08:42:06 GMT
+  recorded_at: Tue, 20 Nov 2018 07:50:54 GMT
 recorded_with: VCR 3.0.3

--- a/spec/features/invites/create_spec.rb
+++ b/spec/features/invites/create_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe 'Invite features CREATE', vcr: { record: :new_episodes } do
   before do
+
+
     visit '/invites/new'
   end
 

--- a/spec/services/slack/invite_spec.rb
+++ b/spec/services/slack/invite_spec.rb
@@ -1,16 +1,24 @@
 require 'rails_helper'
 
 describe Slack::Invite, vcr: { record: :new_episodes } do
+  subject(:invite_service) { described_class.new(email: email) }
+
   let(:email) { 'new-user@mail.com' }
-  subject { described_class.new(email: email) }
+  let(:slack_client) { instance_double(Slack::Client) }
+
+  before do
+    allow(Slack::Client).to receive(:new)
+      .with(url: 'https://slack.com/api/users.admin.invite', params: {email: email, resend: true})
+      .and_return(slack_client)
+  end
 
   describe '#call' do
-    context 'when success' do
-      it { expect(subject.call).to be_truthy }
-    end
+    specify do
+      allow(slack_client).to receive(:call)
 
-    context 'when invited second time' do
-      it { expect(subject.call).to be_falsey }
+      invite_service.call
+
+      expect(slack_client).to have_received(:call)
     end
   end
 


### PR DESCRIPTION
### Description

We were using real token for making requests.
It was blocked by Slack.
As it is better practice let's stub calls instead making real.