### PR TITLE
Fix report bug link breaking the header

### DIFF
--- a/app/views/layouts/app/_header.slim
+++ b/app/views/layouts/app/_header.slim
@@ -76,7 +76,7 @@ header.pk-header class="#{yield(:main_header_class)}"
                   li.pk-header__li-list-item = link_to 'about','/about'
 
               li.pk-list__unit
-                = link_to 'Report a bug',
+                = link_to 'bug?',
                         'https://github.com/pivorakmeetup/pivorak-web-app/issues/new?labels=bug'
               - if user_signed_in?
                 / .pk-avatar     = image_tag gravatar_url(current_user)


### PR DESCRIPTION
### Description

`Report a Bug` text is breaking the header.
Look into screenshots.

### Screenshots

| Production                                     | Locally                                       |
| ------------------------------------------- | ------------------------------------------- |
| <img width="1280" alt="screen shot 2018-12-12 at 4 08 58 pm" src="https://user-images.githubusercontent.com/5591973/49875023-a8dcf500-fe28-11e8-9282-110cf0a4d9ec.png"> | <img width="1280" alt="screen shot 2018-12-12 at 4 09 00 pm" src="https://user-images.githubusercontent.com/5591973/49875024-a8dcf500-fe28-11e8-95e4-734864b8d2bf.png"> |

