### PR TITLE
Break a long word in the body of the page

### DIFF
--- a/app/assets/stylesheets/app/base/_base.scss
+++ b/app/assets/stylesheets/app/base/_base.scss
@@ -18,6 +18,7 @@ body {
   line-height: $main-line-height;
   color: $main-color;
   position: relative;
+  overflow-wrap: break-word;
   &:after {
     content: "";
     background: transparent image-url("paper-imit-bg.png") repeat center;


### PR DESCRIPTION
There could be too long words on a page. Usually, on mobile view, it
causes redundant horizontal scroll. For instance, see
[this page](https://pivorak.com/talks/rails-5-2) on mobile view:

![combined](https://user-images.githubusercontent.com/6443532/50047105-e0ad9c00-00b7-11e9-93c0-ec2b73744924.png)

About `overflow-wrap`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap