### PR TITLE
Hide donate feature

### DIFF
--- a/app/controllers/donate_controller.rb
+++ b/app/controllers/donate_controller.rb
@@ -1,4 +1,7 @@
 class DonateController < ApplicationController
+  # Disabled because of tax thing.
+  # Ask at Slack #core-team if it can be enabled.
+  before_action :redirect_home
   helper_method :form, :locale
   layout 'devise'
 
@@ -16,6 +19,10 @@ class DonateController < ApplicationController
   end
 
   private
+
+  def redirect_home
+    redirect_to root_path
+  end
 
   def locale
     # hardcoded for now

--- a/app/views/layouts/app/_header.slim
+++ b/app/views/layouts/app/_header.slim
@@ -91,5 +91,6 @@ header.pk-header class="#{yield(:main_header_class)}"
                 li.pk-list__unit = register_link
                 li.pk-list__unit = login_link
 
-              li.pk-list__unit
-                = donate_link(class: 'btn')
+              / li.pk-list__unit
+              /   - if current_user&.admin?
+              /     = donate_link(class: 'btn')

--- a/spec/features/donate/create_spec.rb
+++ b/spec/features/donate/create_spec.rb
@@ -1,10 +1,14 @@
 RSpec.describe 'Create Donation' do
+  pending 'Disabled because of tax thing'
+
   subject { page }
 
-  before { visit donate_path }
+  before do
+    visit donate_path
+  end
 
   context 'when terms of use are accepted' do
-    it 'toggles submit and payment button when checkbox is clicked' do
+    xit 'toggles submit and payment button when checkbox is clicked' do
       expect(page).to have_selector('.js-donate-form-payment-btn', visible: true)
       expect(page).to have_selector('.js-donate-form-validation-btn', visible: false)
 
@@ -16,7 +20,7 @@ RSpec.describe 'Create Donation' do
   end
 
   context 'when terms of use not accepted' do
-    it 'does not proceed with payment' do
+    xit 'does not proceed with payment' do
       click_button I18n.t('pages.donate.submit_btn', locale: :ua)
 
       expect(page).to have_content I18n.t('pages.donate.failure', locale: :ua)

--- a/spec/features/donations/donation_spec.rb
+++ b/spec/features/donations/donation_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe 'Donate Process' do
+  pending 'Disabled because of tax thing'
   subject { page }
 
   before { visit root_path }
 
-  it 'home page should have donate link' do
+  xit 'home page should have donate link' do
     expect(page).to have_selector('a', text: 'Donate')
   end
 end


### PR DESCRIPTION
### Description

Hide `donate` because of tax office issues.
Also, redirect if person will visit `/donate` directly.