### PR TITLE
Allow admin to check in person from the UI

### DIFF
--- a/app/controllers/admin/visit_request/check_in_controller.rb
+++ b/app/controllers/admin/visit_request/check_in_controller.rb
@@ -5,11 +5,8 @@ module Admin
 
       def show
         @visit_request, status = ::VisitRequest::CheckIn.new(visit_request).call
-        if params[:redirect_back]
-          redirect_back(fallback_location: admin_path)
-        else
-          render status
-        end
+
+        render status
       end
 
       private

--- a/app/controllers/admin/visit_request/check_in_controller.rb
+++ b/app/controllers/admin/visit_request/check_in_controller.rb
@@ -5,7 +5,11 @@ module Admin
 
       def show
         @visit_request, status = ::VisitRequest::CheckIn.new(visit_request).call
-        render status
+        if params[:redirect_back]
+          redirect_back(fallback_location: admin_path)
+        else
+          render status
+        end
       end
 
       private

--- a/app/controllers/admin/visit_request/toggle_visit_controller.rb
+++ b/app/controllers/admin/visit_request/toggle_visit_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class VisitRequest
     class ToggleVisitController < VisitRequest::BaseController
       def update
+        ::VisitRequest::CheckIn.new(visit_request).call
         ::VisitRequest::ToggleVisit.call(visit_request)
 
         ::VisitRequest::RealTimeUpdate.call(visit_request)

--- a/app/controllers/admin/visit_request/toggle_visit_controller.rb
+++ b/app/controllers/admin/visit_request/toggle_visit_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class VisitRequest
     class ToggleVisitController < VisitRequest::BaseController
       def update
-        ::VisitRequest::CheckIn.new(visit_request).call
+        ::VisitRequest::CheckIn.call(visit_request)
         ::VisitRequest::ToggleVisit.call(visit_request)
 
         ::VisitRequest::RealTimeUpdate.call(visit_request)

--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -18,7 +18,7 @@ module Admin
     end
 
     def visit_requests
-      @visit_requests ||= search_against(base_scope).order('users.first_name, users.last_name').includes(:user).order(:id)
+      @visit_requests ||= search_against(base_scope).includes(:user).order('users.first_name, users.last_name')
     end
 
     def base_scope

--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -18,7 +18,7 @@ module Admin
     end
 
     def visit_requests
-      @visit_requests ||= search_against(base_scope).includes(:user).order('users.first_name, users.last_name')
+      @visit_requests ||= search_against(base_scope).includes(:user, :event).order('users.first_name, users.last_name')
     end
 
     def base_scope

--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -18,7 +18,7 @@ module Admin
     end
 
     def visit_requests
-      @visit_requests ||= search_against(base_scope).includes(:user).order(:id)
+      @visit_requests ||= search_against(base_scope).order('users.first_name, users.last_name').includes(:user).order(:id)
     end
 
     def base_scope

--- a/app/helpers/admin/visit_requests_helper.rb
+++ b/app/helpers/admin/visit_requests_helper.rb
@@ -46,16 +46,12 @@ module Admin
         remote: true
     end
 
-    def visit_request_visited_link(visit_request)
-      label      = visit_request.visited? ? 'waiting' : 'hello'
-      btn_class  = visit_request.visited? ? 'grey' : 'green'
-      i18n_label = t(label, scope: 'visit_requests')
+    def visit_request_check_in_link(visit_request)
+      return t('visit_request.check_in.already_checked_in') if visit_request.visited?
 
-      link_to i18n_label,
-        admin_event_visit_request_toggle_visit_path(visit_request.event, visit_request),
-        method: :put, class: ['ui button', btn_class],
-        data: { confirm: t('phrases.confirm') },
-        remote: true
+      link_to t('visit_request.check_in.plural'),
+      admin_visit_request_check_in_path(visit_request.token, redirect_back: true),
+        class: ['ui button', 'green']
     end
   end
 end

--- a/app/helpers/admin/visit_requests_helper.rb
+++ b/app/helpers/admin/visit_requests_helper.rb
@@ -47,11 +47,14 @@ module Admin
     end
 
     def visit_request_check_in_link(visit_request)
-      return t('visit_request.check_in.already_checked_in') if visit_request.visited?
-
-      link_to t('visit_request.check_in.plural'),
-      admin_visit_request_check_in_path(visit_request.token, redirect_back: true),
-        class: ['ui button', 'green']
+      if !visit_request.checked_in_at
+        link_to t('check_in', scope: 'visit_requests'),
+        admin_event_visit_request_toggle_visit_path(visit_request.event, visit_request),
+        method: :put, class: ['ui button', 'green'],
+        remote: true
+      else
+        t('already_checked_in', scope: 'visit_requests')
+      end
     end
   end
 end

--- a/app/helpers/admin/visit_requests_helper.rb
+++ b/app/helpers/admin/visit_requests_helper.rb
@@ -47,7 +47,7 @@ module Admin
     end
 
     def visit_request_check_in_link(visit_request)
-      if !visit_request.checked_in_at
+      if !visit_request.checked_in?
         link_to t('check_in', scope: 'visit_requests'),
         admin_event_visit_request_toggle_visit_path(visit_request.event, visit_request),
         method: :put, class: ['ui button', 'green'],

--- a/app/models/visit_request.rb
+++ b/app/models/visit_request.rb
@@ -32,4 +32,8 @@ class VisitRequest < ApplicationRecord
   def final_decision?
     confirmed? || refused?
   end
+
+  def checked_in?
+    checked_in_at.present?
+  end
 end

--- a/app/services/visit_request/check_in.rb
+++ b/app/services/visit_request/check_in.rb
@@ -9,8 +9,6 @@ class VisitRequest
                  :not_found
                elsif visit_request.visited?
                  :already_visited
-               elsif  !visit_request.confirmed?
-                 :invalid_status
                else
                  :success
                end

--- a/app/views/admin/visit_request/check_in/already_visited.slim
+++ b/app/views/admin/visit_request/check_in/already_visited.slim
@@ -6,6 +6,6 @@
   p
     i.empty.ban.icon.red
     - if visit_request.checked_in_at
-      = t('visit_request.check_in.already_checked_in', time_ago: time_ago_in_words(visit_request.checked_in_at, include_seconds: true))
+      = t('visit_request.check_in.already_checked_in')
 
   = render 'find_visitor_search'

--- a/app/views/admin/visit_requests/_visit_request.slim
+++ b/app/views/admin/visit_requests/_visit_request.slim
@@ -1,12 +1,12 @@
 td = bool_icon(visit_request.user.verified?)
 td = link_to visit_request.user.full_name, edit_admin_member_path(visit_request.user), target: '_blank'
 
-- if event.live?
-  td.center.aligned = visit_request_visited_link(visit_request)
-- else
+- unless event.live?
   td.center.aligned = visit_request_list_link(visit_request)
   td.center.aligned = visit_request_status_label(visit_request.status)
-  - unless event.confirmation? || event.passed?
-    td.center.aligned
-      = admin_approve_visit_request_link(visit_request)
-      = admin_cancel_visit_request_link(visit_request)
+td.center.aligned
+  - if event.registration? || event.confirmation?
+    = admin_approve_visit_request_link(visit_request)
+    = admin_cancel_visit_request_link(visit_request)
+  - if event.live? || event.passed?
+    = visit_request_check_in_link(visit_request)

--- a/app/views/admin/visit_requests/index.slim
+++ b/app/views/admin/visit_requests/index.slim
@@ -16,13 +16,11 @@
       tr
         th = 'Verified?'
         th = t 'words.name'
-        - if event.live?
-          th.center.aligned = t 'visit_requests.visited'
-        - else
+        - unless event.live?
           th.center.aligned = t 'words.list'
           th.center.aligned = t 'words.status'
-          - unless event.confirmation? || event.passed?
-            th.status
+        th.center.aligned
+          = t 'words.actions'
 
     tbody
       - visit_requests.each do |visit_request|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # }
 
   config.after_initialize do
-    Bullet.enable = false
+    Bullet.enable = true
     Bullet.raise = true
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # }
 
   config.after_initialize do
-    Bullet.enable = true
+    Bullet.enable = false
     Bullet.raise = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   pivorak_description: A Ruby Community in Lviv, featuring monthly meetups with beer and crawfish :)
 
   words:
+    actions: Actions
     agenda: agenda
     app: App
     all: All
@@ -176,7 +177,7 @@ en:
       plural: Check In
       search: 'Find by name:'
       name: "Name: <b>%{first_name}</b> %{last_name}"
-      already_checked_in: Already checked in %{time_ago} ago
+      already_checked_in: Already checked in
       invalid_status: "Invalid status: %{status}"
       not_found: Not Found
       event: "Event: %{title}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,8 +200,8 @@ en:
     main_list: Main
     waiting_list: Waiting
     visited: Visited
-    hello: Hello!
-    waiting: Waiting
+    check_in: Check In
+    already_checked_in: Already Checked In
     confirm: Confirm
     refuse: Refuse
     messages:

--- a/spec/features/admin/visit_requests/check_in_spec.rb
+++ b/spec/features/admin/visit_requests/check_in_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe 'Visit Requests Check In' do
     it { expect(page).to have_content 'Already checked in' }
   end
 
-  context 'when visit request has invalid status' do
-    let(:visit_request) { create(:visit_request, :refused, event: event, user: user) }
-
-    it { expect(page).to have_content 'refused' }
-  end
-
   context 'when confirmed visit request found' do
     let(:visit_request) { create(:visit_request, :confirmed, event: event, user: user) }
 

--- a/spec/features/admin/visit_requests/toggle_visit_spec.rb
+++ b/spec/features/admin/visit_requests/toggle_visit_spec.rb
@@ -8,16 +8,14 @@ RSpec.describe 'Visit Requests TOGGLE LIST' do
     visit_page.call
   end
 
-  it 'checking in the visitor and link is changed to text' do
+  it 'checking in the visitor' do
     visit_page.call
 
     expect(page).to have_link I18n.t('visit_request.check_in.plural')
     expect(page).to_not have_content I18n.t('visit_request.check_in.already_checked_in')
 
     click_link I18n.t('visit_request.check_in.plural')
-    visit_page.call
 
-    expect(page).not_to have_link I18n.t('visit_request.check_in.plural')
-    expect(page).to have_content I18n.t('visit_request.check_in.already_checked_in')
+    expect(visit_request.reload.checked_in_at).to be_present
   end
 end

--- a/spec/features/admin/visit_requests/toggle_visit_spec.rb
+++ b/spec/features/admin/visit_requests/toggle_visit_spec.rb
@@ -8,21 +8,16 @@ RSpec.describe 'Visit Requests TOGGLE LIST' do
     visit_page.call
   end
 
-  describe 'toggling from one list to another' do
-    it { expect(page).to have_link 'Hello!', count: 1 }
+  it 'checking in the visitor and link is changed to text' do
+    visit_page.call
 
-    it 'toggle to the main list' do
-      click_link 'Hello!'
-      visit_page.call
+    expect(page).to have_link I18n.t('visit_request.check_in.plural')
+    expect(page).to_not have_content I18n.t('visit_request.check_in.already_checked_in')
 
-      expect(page).to have_link 'Waiting', count: 1
-      expect(page).to_not have_link 'Hello!', count: 1
+    click_link I18n.t('visit_request.check_in.plural')
+    visit_page.call
 
-      click_link 'Waiting'
-      visit_page.call
-
-      expect(page).to have_link 'Hello!', count: 1
-      expect(page).to_not have_link 'Waiting', count: 1
-    end
+    expect(page).not_to have_link I18n.t('visit_request.check_in.plural')
+    expect(page).to have_content I18n.t('visit_request.check_in.already_checked_in')
   end
 end

--- a/spec/models/visit_request_spec.rb
+++ b/spec/models/visit_request_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe VisitRequest do
+  describe '#checked_in?' do
+    subject { build_stubbed(:visit_request) }
+
+    its(:checked_in?) { is_expected.to be_falsey }
+
+    context 'when checked in' do
+      subject { build_stubbed(:visit_request, :visited) }
+
+      its(:checked_in?) { is_expected.to be_truthy }
+    end
+  end
+end

--- a/spec/services/visit_request/check_in_spec.rb
+++ b/spec/services/visit_request/check_in_spec.rb
@@ -30,14 +30,6 @@ RSpec.describe VisitRequest::CheckIn do
       end
     end
 
-    context 'when rejected' do
-      let(:visit_request) { create(:visit_request, :refused) }
-
-      it 'returns object and status' do
-        expect(call).to eq([visit_request, :invalid_status])
-      end
-    end
-
     context 'when visit request not passed' do
       let(:visit_request) { nil }
 


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/684)

### Description

read issue description ☝️ 

- Add `Check in` word and allow admin to `check in` user after event is ended.
- Visit requests will be ordered by `user.first/last name`
- Remove check by `visit request` status while `check in`. Let's make it simpler.

### How to test instructions

- Visit http://localhost:3000/admin/events/pivorak-elixir-edition/visit_requests
- Check in button is on the right in `actions` column 

### Screenshots

<img width="1280" alt="screen shot 2018-12-29 at 2 26 44 pm" src="https://user-images.githubusercontent.com/5591973/50538294-cf639580-0b75-11e9-877b-952a3cf8743b.png">