### PR TITLE
Add ability to invite user by email

### DIFF
--- a/app/controllers/admin/visit_request/import_controller.rb
+++ b/app/controllers/admin/visit_request/import_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class VisitRequest
     class ImportController < VisitRequest::BaseController
       def create
-        ::VisitRequest::Import.call(event, params[:separator], params[:emails_list])
+        ::VisitRequest::Import.call(event: event, emails: params[:emails_list], separator: params[:separator])
 
         default_redirect
       end

--- a/app/controllers/admin/visit_request/invite_controller.rb
+++ b/app/controllers/admin/visit_request/invite_controller.rb
@@ -1,0 +1,33 @@
+module Admin
+  class VisitRequest
+    class InviteController < VisitRequest::BaseController
+      helper_method :form, :event
+
+      before_action :only_supervisor!
+
+      def create
+        if form.valid?
+          ::VisitRequest::Invite.call(emails: form.emails, event: event)
+          flash[:notice] = t('visit_request.invite.success')
+          redirect_to admin_event_visit_requests_path(event)
+        else
+          render :new
+        end
+      end
+
+      private
+
+      def form
+        @form ||= ::InviteByEmailForm.new(visit_request_params)
+      end
+
+      def visit_request_params
+        params.fetch(:invite_by_email_form, {}).permit(:emails)
+      end
+
+      def event
+        @event ||= Event.friendly.find(params[:event_id])
+      end
+    end
+  end
+end

--- a/app/forms/Invite_by_email_form.rb
+++ b/app/forms/Invite_by_email_form.rb
@@ -1,0 +1,28 @@
+class InviteByEmailForm
+  include ActiveModel::Model
+
+  DELIMITER = ','.freeze
+
+  attr_accessor :emails
+
+  validates :emails, presence: true
+  validate :emails_are_valid
+
+  private
+
+  def emails_are_valid
+    return if emails.blank?
+
+    invalid_emails = email_list.select do |email|
+      !email.strip.match(Devise.email_regexp)
+    end
+
+    return if invalid_emails.empty?
+
+    errors.add(:emails, I18n.t('invite_by_email_form.emails.error', invalid_emails: invalid_emails.join(DELIMITER)))
+  end
+
+  def email_list
+    emails.split(DELIMITER).reject(&:blank?)
+  end
+end

--- a/app/helpers/admin/emails_helper.rb
+++ b/app/helpers/admin/emails_helper.rb
@@ -35,5 +35,9 @@ module Admin
               new_admin_email_path(recipient_ids: ids),
               class: 'ui button'
     end
+
+    def invite_user_link(event)
+      link_to t('visit_requests.invite_user'), new_admin_event_invite_path(event), class: 'ui button blue'
+    end
   end
 end

--- a/app/services/user/import.rb
+++ b/app/services/user/import.rb
@@ -1,0 +1,35 @@
+class User
+  class Import < ApplicationService
+    def initialize(emails:, separator: ',')
+      @separator   = separator.strip
+      @emails = emails
+    end
+
+    def call
+      (prepared_emails - existing_user_emails).each do |email|
+        first_name = name_email_part(email).first
+        last_name = name_email_part(email).last
+
+        user = User.new(email: email, first_name: first_name, last_name: last_name)
+
+        User::Create.call(user, {}, synthetic: true)
+      end
+    end
+
+    private
+
+    attr_reader :emails, :separator
+
+    def prepared_emails
+      @prepared_emails ||= emails.split(separator).map(&:strip).reject(&:blank?)
+    end
+
+    def existing_user_emails
+      User.where(email: prepared_emails).pluck(:email)
+    end
+
+    def name_email_part(email)
+      email.split('@')[0].split('.')
+    end
+  end
+end

--- a/app/services/visit_request/import.rb
+++ b/app/services/visit_request/import.rb
@@ -1,26 +1,26 @@
 class VisitRequest
   class Import < ApplicationService
-    def initialize(event, separator, emails_list)
+    def initialize(event:, emails:, separator: ',')
       @event       = event
       @separator   = separator.strip
-      @emails_list = emails_list
+      @emails = emails
     end
 
+    # @return <VisitRequest> returns list of newly created/found visit requests
     def call
-      emails_list.split(separator).each do |email|
+      emails.split(separator).map do |email|
         user = ::User.find_by(email: email.strip)
         next unless user
 
         event.visit_requests.where(
           user: user,
-          status: :confirmed,
-          visited: true
+          status: :confirmed
         ).first_or_create
-      end
+      end.compact
     end
 
     private
 
-    attr_reader :event, :emails_list, :separator
+    attr_reader :event, :emails, :separator
   end
 end

--- a/app/services/visit_request/invite.rb
+++ b/app/services/visit_request/invite.rb
@@ -1,0 +1,20 @@
+class VisitRequest
+  class Invite < ApplicationService
+    def initialize(emails:, event:)
+      @emails = emails
+      @event  = event
+    end
+
+    def call
+      ::User::Import.call(emails: emails)
+      visit_requests = ::VisitRequest::Import.call(event: event, emails: emails)
+      visit_requests.each do |visit_request|
+        VisitRequestMailer.attendance_confirmed(visit_request).deliver_later
+      end
+    end
+
+    private
+
+    attr_reader :emails, :event
+  end
+end

--- a/app/views/admin/visit_request/invite/new.slim
+++ b/app/views/admin/visit_request/invite/new.slim
@@ -1,0 +1,5 @@
+= simple_form_for form, url: admin_event_invite_path(event) do |f|
+  .one.field
+    = f.input :emails, input_html: {id: :emails}, as: :text, label: t('invite_by_email_form.emails.label')
+  .one.field
+    = f.button :submit, value: t('invite_by_email_form.submit')

--- a/app/views/admin/visit_requests/_links.slim
+++ b/app/views/admin/visit_requests/_links.slim
@@ -1,4 +1,5 @@
 .twelve.wide.column
+  = invite_user_link(event)
   = send_email_to_recipient_ids_link(visitors_ids)
   = send_email_to_attendees_link(confirmed_ids)
   = send_email_to_applied_users_link(applied_ids)

--- a/app/views/admin/visit_requests/index.slim
+++ b/app/views/admin/visit_requests/index.slim
@@ -9,7 +9,7 @@
   .six.wide.column.bottom.aligned
     = render 'admin/shared/search_bar', path: admin_event_visit_requests_path
 
-  = render 'emails'
+  = render 'links'
 
   table#visit-requests.ui.very.basic.table
     thead

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,9 @@ en:
       event: "Event: %{title}"
       visits_counter: "Visits: %{count}"
       newbie: Hello newbie!
+    invite:
+      plural: Invite users
+      success: Users were successfully invited
 
   visit_requests:
     send_email_to_visitors: 'Send email to visitors'
@@ -190,6 +193,7 @@ en:
     send_email_to_applied: 'Send email to applied users'
     send_email_to_pending: 'Send email to pending users'
     send_email_to_approved: 'Send email to approved users'
+    invite_user: 'Invite user'
     attend: Attend
     already_created: Already attending
     approve: Approve
@@ -267,3 +271,9 @@ en:
     next_event: Next event will happen on %{upcoming_date}.
     cfp_is_open: Call for speakers is open!
     follow_us: follow us to keep in touch
+
+  invite_by_email_form:
+    submit: Invite
+    emails:
+      label: 'Emails separated by comma. Example: john@m.com OR john@m.com, peter@m.com'
+      error: "Should be comma separate list. Following emails are invalid: %{invalid_emails}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
           post :send_confirmations, to: 'visit_request/send_confirmations#create'
           post :send_confirmation_reminders, to: 'visit_request/send_confirmation_reminders#create'
           post :import,             to: 'visit_request/import#create'
+          resource :invite, only: [:new, :create], controller: 'visit_request/invite'
           get  :report,             to: 'visit_request/report#download'
         end
 

--- a/spec/features/admin/visit_requests/import_spec.rb
+++ b/spec/features/admin/visit_requests/import_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'Visit Requests APPROVE' do
+RSpec.describe 'Visit Requests IMPORT' do
   let(:not_passed_event) { create(:event) }
   let(:passed_event)     { create(:event, status: :passed) }
   let(:user_a)           { create(:user, first_name: 'A', last_name: 'User') }
@@ -18,6 +18,7 @@ RSpec.describe 'Visit Requests APPROVE' do
     before { visit admin_event_visit_requests_path(passed_event) }
 
     it { expect(page).to have_content 'Import' }
+
     it 'import visit requests of users' do
       fill_in 'Emails list', with: emails_list
       click_button 'Import'

--- a/spec/features/admin/visit_requests/invite_spec.rb
+++ b/spec/features/admin/visit_requests/invite_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe 'Visit Request INVITE' do
+  subject { page }
+
+  let(:event) { create(:event) }
+  let(:visit_page) { -> { visit "/admin/events/#{event.slug}/visit_requests/invite/new" } }
+
+  let(:click_user_invite) do
+    assume_admin_logged_in(supervisor: true)
+    visit_page.call
+    fill_in :emails, with: entered_email_data
+    click_button 'Invite'
+  end
+
+  context 'when one email is entered' do
+    let(:entered_email_data) { 'john.joe@email.com' }
+
+    context 'when user with given email exists' do
+      it 'creates visit request for user' do
+        user = create(:user, email: entered_email_data)
+
+        click_user_invite
+
+        expect(VisitRequest.exists?(user_id: user.id, event_id: event.id)).to be_truthy
+      end
+
+      it 'sends email to user' do
+        create(:user, email: entered_email_data)
+
+        click_user_invite
+
+        expect(active_jobs.size).to eq(1)
+        active_job = active_jobs[0]
+        expect(active_job[:job]).to eq ActionMailer::DeliveryJob
+        expect(active_job[:args][0]).to eq 'VisitRequestMailer'
+        expect(active_job[:args][1]).to eq 'attendance_confirmed'
+      end
+    end
+
+    context 'when user with given email does not exist' do
+      it 'creates user with visit request for user' do
+        click_user_invite
+
+        user = User.find_by!(email: entered_email_data)
+        expect(VisitRequest.exists?(user_id: user.id, event_id: event.id)).to be_truthy
+      end
+    end
+
+    context 'when email is custom' do
+      let(:entered_email_data) { 'john@email.com' }
+
+      it 'creates user with visit request for user' do
+        click_user_invite
+
+        user = User.find_by!(email: entered_email_data)
+        expect(VisitRequest.exists?(user_id: user.id, event_id: event.id)).to be_truthy
+      end
+    end
+  end
+
+  context 'when list of email are entered' do
+    let(:entered_email_data) { 'john.joe@gmail.com,  ivan@gmail.com,  , ' }
+
+    it 'creates visit requests for given email with approved status' do
+      click_user_invite
+
+      users = User.where(email: ['john.joe@gmail.com', 'ivan@gmail.com'])
+
+      expect(users.count).to eq(2)
+      expect(VisitRequest.where(user_id: users.ids, event_id: event.id).count).to eq(2)
+    end
+
+    it 'sends emails to each user' do
+      click_user_invite
+
+      expect(active_jobs.size).to eq(2)
+
+      active_jobs.each do |job|
+        expect(job[:job]).to eq ActionMailer::DeliveryJob
+        expect(job[:args][0]).to eq 'VisitRequestMailer'
+        expect(job[:args][1]).to eq 'attendance_confirmed'
+      end
+    end
+  end
+
+  context 'when invalid email is entered' do
+    let(:entered_email_data) { 'johnemail.com' }
+
+    it 'does nothing with users and emails' do
+      click_user_invite
+
+      expect(User.where(email: entered_email_data)).to be_empty
+      expect(active_jobs).to be_empty
+    end
+  end
+
+  context 'when bad list of email are entered' do
+    let(:entered_email_data) { 'johne.com, pe@.a.a.a' }
+
+    it 'does nothing with users and emails' do
+      click_user_invite
+
+      expect(User.where(email: entered_email_data)).to be_empty
+      expect(active_jobs).to be_empty
+    end
+  end
+end

--- a/spec/services/visit_request/import_spec.rb
+++ b/spec/services/visit_request/import_spec.rb
@@ -6,9 +6,9 @@ describe VisitRequest::Import do
   let(:user_b)      { create(:user) }
   let(:user_c)      { create(:user) }
   let(:separator)   { ', ' }
-  let(:emails_list) { [user_a, user_b].map(&:email).join(separator) + ', fake@user.com' }
+  let(:emails) { [user_a, user_b].map(&:email).join(separator) + ', fake@user.com' }
 
-  subject { described_class.new(event, separator, emails_list) }
+  subject { described_class.new(emails: emails, separator: separator, event: event) }
 
   describe '#call' do
     before { subject.call }
@@ -20,6 +20,5 @@ describe VisitRequest::Import do
 
     it { expect(event.visit_requests.first.user_id).to eq user_a.id }
     it { expect(event.visit_requests.first.status).to eq VisitRequest::CONFIRMED.to_s }
-    it { expect(event.visit_requests.first.visited).to eq true }
   end
 end


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/673)

### Description

Several times Sofiia asked me to invite particular people and I did it from `rails console`.
This feature will allow admin to invite user from web interface.

### How to test instructions

- Visit http://localhost:3000/admin/events/pivorak-conference-717203c4-b08e-4dcd-9787-6c6bb2e6b63e/visit_requests/new
- enter valid email
- enter invalid email
- enter list of emails separated by comas

### Screenshots

<img width="1280" alt="screen shot 2018-12-30 at 12 05 02 pm" src="https://user-images.githubusercontent.com/5591973/50546128-2aa38f80-0c2b-11e9-9355-e29df7bd82f7.png">

