### PR TITLE
Spread bulk emails through time

### DIFF
--- a/app/services/bulk_email_sender.rb
+++ b/app/services/bulk_email_sender.rb
@@ -1,0 +1,21 @@
+class BulkEmailSender < ApplicationService
+  BULK_SIZE = 100
+
+  def initialize(mailer_klass:, method_name:, scope:)
+    @mailer_klass = mailer_klass
+    @method_name = method_name
+    @scope = scope
+  end
+
+  def call
+    scope.each_slice(BULK_SIZE).with_index do |objects, index|
+      objects.each do |object|
+        mailer_klass.public_send(method_name, object).deliver_later(wait: index.hour)
+      end
+    end
+  end
+
+  private
+
+  attr_reader :mailer_klass, :method_name, :scope
+end

--- a/app/services/event/send_confirmation_reminders.rb
+++ b/app/services/event/send_confirmation_reminders.rb
@@ -1,12 +1,16 @@
 class Event
   class SendConfirmationReminders < ApplicationService
+    EMAILS_BULK_SIZE = 100
+
     def initialize(event)
       @event = event
     end
 
     def call
-      event.visit_requests.approved.each_with_index do |visit_request, index|
-        VisitRequestMailer.confirmation_reminder(visit_request).deliver_later(wait: index.minute)
+      event.visit_requests.approved.each_slice(EMAILS_BULK_SIZE).with_index do |visit_requests, index|
+        visit_requests.each do |visit_request|
+          VisitRequestMailer.confirmation_reminder(visit_request).deliver_later(wait: index.hour)
+        end
       end
     end
 

--- a/app/services/event/send_confirmation_reminders.rb
+++ b/app/services/event/send_confirmation_reminders.rb
@@ -1,17 +1,11 @@
 class Event
   class SendConfirmationReminders < ApplicationService
-    EMAILS_BULK_SIZE = 100
-
     def initialize(event)
       @event = event
     end
 
     def call
-      event.visit_requests.approved.each_slice(EMAILS_BULK_SIZE).with_index do |visit_requests, index|
-        visit_requests.each do |visit_request|
-          VisitRequestMailer.confirmation_reminder(visit_request).deliver_later(wait: index.hour)
-        end
-      end
+      BulkEmailSender.call(mailer_klass: VisitRequestMailer, method_name: :confirmation_reminder, scope: event.visit_requests.approved)
     end
 
     private

--- a/app/services/event/send_confirmation_reminders.rb
+++ b/app/services/event/send_confirmation_reminders.rb
@@ -5,8 +5,8 @@ class Event
     end
 
     def call
-      event.visit_requests.approved.each do |visit_request|
-        VisitRequestMailer.confirmation_reminder(visit_request).deliver_later
+      event.visit_requests.approved.each_with_index do |visit_request, index|
+        VisitRequestMailer.confirmation_reminder(visit_request).deliver_later(wait: index.minute)
       end
     end
 

--- a/app/services/event/send_confirmations.rb
+++ b/app/services/event/send_confirmations.rb
@@ -5,8 +5,8 @@ class Event
     end
 
     def call
-      event.visit_requests.final.each do |visit_request|
-        VisitRequestMailer.confirmation(visit_request).deliver_later
+      event.visit_requests.final.each_with_index do |visit_request, index|
+        VisitRequestMailer.confirmation(visit_request).deliver_later(wait: index.minute)
       end
     end
 

--- a/app/services/event/send_confirmations.rb
+++ b/app/services/event/send_confirmations.rb
@@ -1,12 +1,16 @@
 class Event
   class SendConfirmations < ApplicationService
+    EMAILS_BULK_SIZE = 100
+
     def initialize(event)
       @event = event
     end
 
     def call
-      event.visit_requests.final.each_with_index do |visit_request, index|
-        VisitRequestMailer.confirmation(visit_request).deliver_later(wait: index.minute)
+      event.visit_requests.final.each_slice(EMAILS_BULK_SIZE).with_index do |visit_requests, index|
+        visit_requests.each do |visit_request|
+          VisitRequestMailer.confirmation(visit_request).deliver_later(wait: index.hour)
+        end
       end
     end
 

--- a/app/services/event/send_confirmations.rb
+++ b/app/services/event/send_confirmations.rb
@@ -1,17 +1,11 @@
 class Event
   class SendConfirmations < ApplicationService
-    EMAILS_BULK_SIZE = 100
-
     def initialize(event)
       @event = event
     end
 
     def call
-      event.visit_requests.final.each_slice(EMAILS_BULK_SIZE).with_index do |visit_requests, index|
-        visit_requests.each do |visit_request|
-          VisitRequestMailer.confirmation(visit_request).deliver_later(wait: index.hour)
-        end
-      end
+      BulkEmailSender.call(mailer_klass: VisitRequestMailer, method_name: :confirmation, scope: event.visit_requests.final)
     end
 
     private

--- a/spec/services/bulk_email_sender_spec.rb
+++ b/spec/services/bulk_email_sender_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe BulkEmailSender do
+  subject(:service) { described_class.new(mailer_klass: VisitRequestMailer, method_name: :confirmation_reminder, scope: VisitRequest.approved) }
+
+  describe '#call' do
+    subject(:call) { service.call }
+
+    let!(:approved_request) { create(:visit_request, :approved) }
+    let(:last_job) { active_jobs.last }
+
+    it 'sends confirmation reminders to people who did not confirm their attendance' do
+      allow(VisitRequestMailer).to receive(:confirmation_reminder).with(approved_request).and_call_original
+
+      call
+
+      expect(VisitRequestMailer).to have_received(:confirmation_reminder).once
+
+      expect(active_jobs.size).to eq(1)
+      expect(last_job[:job]).to eq ActionMailer::DeliveryJob
+      expect(last_job[:args][0]).to eq 'VisitRequestMailer'
+      expect(last_job[:args][1]).to eq 'confirmation_reminder'
+    end
+
+    it 'spreads sending through the time' do
+      stub_const("BulkEmailSender::BULK_SIZE", 1)
+
+      create(:visit_request, :approved)
+      mocked_mailer = double('Dummy', deliver_later: true)
+
+      allow(VisitRequestMailer).to receive(:confirmation_reminder).and_return(mocked_mailer)
+
+      call
+
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.hour).once
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.hour).once
+    end
+  end
+end

--- a/spec/services/event/send_confirmation_reminders_spec.rb
+++ b/spec/services/event/send_confirmation_reminders_spec.rb
@@ -29,6 +29,8 @@ describe Event::SendConfirmationReminders do
     end
 
     it 'spreads sending through the time' do
+      stub_const("Event::SendConfirmationReminders::EMAILS_BULK_SIZE", 1)
+
       create(:visit_request, :approved, event: event)
       mocked_mailer = double('Dummy', deliver_later: true)
 
@@ -36,8 +38,8 @@ describe Event::SendConfirmationReminders do
 
       call
 
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.minute).once
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.minute).once
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.hour).once
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.hour).once
     end
   end
 end

--- a/spec/services/event/send_confirmation_reminders_spec.rb
+++ b/spec/services/event/send_confirmation_reminders_spec.rb
@@ -28,18 +28,12 @@ describe Event::SendConfirmationReminders do
       expect(last_job[:args][1]).to eq 'confirmation_reminder'
     end
 
-    it 'spreads sending through the time' do
-      stub_const("Event::SendConfirmationReminders::EMAILS_BULK_SIZE", 1)
-
-      create(:visit_request, :approved, event: event)
-      mocked_mailer = double('Dummy', deliver_later: true)
-
-      allow(VisitRequestMailer).to receive(:confirmation_reminder).and_return(mocked_mailer)
+    it 'uses bulk email sender' do
+      allow(BulkEmailSender).to receive(:call).with(mailer_klass: VisitRequestMailer, method_name: :confirmation_reminder, scope: [approved_request])
 
       call
 
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.hour).once
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.hour).once
+      expect(BulkEmailSender).to have_received(:call)
     end
   end
 end

--- a/spec/services/event/send_confirmations_spec.rb
+++ b/spec/services/event/send_confirmations_spec.rb
@@ -28,6 +28,8 @@ describe Event::SendConfirmations do
     end
 
     it 'spreads sending through the time' do
+      stub_const("Event::SendConfirmations::EMAILS_BULK_SIZE", 1)
+
       create(:visit_request, :confirmed, event: event)
       mocked_mailer = double('Dummy', deliver_later: true)
 
@@ -35,8 +37,8 @@ describe Event::SendConfirmations do
 
       call
 
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.minute).once
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.minute).once
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.hour)
+      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.hour)
     end
   end
 end

--- a/spec/services/event/send_confirmations_spec.rb
+++ b/spec/services/event/send_confirmations_spec.rb
@@ -1,38 +1,37 @@
 require 'rails_helper'
 
-describe Event::SendConfirmationReminders do
+describe Event::SendConfirmations do
   subject(:service) { described_class.new(event) }
   let(:event) { create(:event) }
 
   describe '#call' do
     subject(:call) { service.call }
 
-    let!(:approved_request) { create(:visit_request, :approved, event: event) }
+    let!(:confirmed_request) { create(:visit_request, :confirmed, event: event) }
     let(:last_job) { active_jobs.last }
     before do
-      create(:visit_request, :confirmed, event: event)
       create(:visit_request, :refused, event: event)
       create(:visit_request, :approved)
     end
 
     it 'sends confirmation reminders to people who did not confirm their attendance' do
-      allow(VisitRequestMailer).to receive(:confirmation_reminder).with(approved_request).and_call_original
+      allow(VisitRequestMailer).to receive(:confirmation).with(confirmed_request).and_call_original
 
       call
 
-      expect(VisitRequestMailer).to have_received(:confirmation_reminder).once
+      expect(VisitRequestMailer).to have_received(:confirmation).once
 
       expect(active_jobs.size).to eq(1)
       expect(last_job[:job]).to eq ActionMailer::DeliveryJob
       expect(last_job[:args][0]).to eq 'VisitRequestMailer'
-      expect(last_job[:args][1]).to eq 'confirmation_reminder'
+      expect(last_job[:args][1]).to eq 'confirmation'
     end
 
     it 'spreads sending through the time' do
-      create(:visit_request, :approved, event: event)
+      create(:visit_request, :confirmed, event: event)
       mocked_mailer = double('Dummy', deliver_later: true)
 
-      allow(VisitRequestMailer).to receive(:confirmation_reminder).and_return(mocked_mailer)
+      allow(VisitRequestMailer).to receive(:confirmation).and_return(mocked_mailer)
 
       call
 

--- a/spec/services/event/send_confirmations_spec.rb
+++ b/spec/services/event/send_confirmations_spec.rb
@@ -27,18 +27,12 @@ describe Event::SendConfirmations do
       expect(last_job[:args][1]).to eq 'confirmation'
     end
 
-    it 'spreads sending through the time' do
-      stub_const("Event::SendConfirmations::EMAILS_BULK_SIZE", 1)
-
-      create(:visit_request, :confirmed, event: event)
-      mocked_mailer = double('Dummy', deliver_later: true)
-
-      allow(VisitRequestMailer).to receive(:confirmation).and_return(mocked_mailer)
+    it 'uses bulk email sender' do
+      allow(BulkEmailSender).to receive(:call).with(mailer_klass: VisitRequestMailer, method_name: :confirmation, scope: [confirmed_request])
 
       call
 
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 0.hour)
-      expect(mocked_mailer).to have_received(:deliver_later).with(wait: 1.hour)
+      expect(BulkEmailSender).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/647)

### Issue

We can not send more than 100 emails per hour.

### Possible solutions
- switch to other mail service: **could not find free service** Any suggestions ?
- spread sending through time

### Description

This is simple hack that can help us with Mailgun issue.
I know it is not smart or bulletproof, but I think it is enough to make us safe from email errors.

All suggestions are appreciated.