### PR TITLE
Do not order visit requests by user name when search is enabled

### DIFF
--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -19,10 +19,10 @@ module Admin
 
     def visit_requests
       @visit_requests ||= if search?
-        search_against(base_scope).includes(:user, :event)
-      else
-        base_scope.includes(:user, :event).order('users.first_name, users.last_name')
-      end
+                            search_against(base_scope).includes(:user, :event)
+                          else
+                            base_scope.includes(:user, :event).order('users.first_name, users.last_name')
+                          end
     end
 
     def search?

--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -18,7 +18,15 @@ module Admin
     end
 
     def visit_requests
-      @visit_requests ||= search_against(base_scope).includes(:user, :event).order('users.first_name, users.last_name')
+      @visit_requests ||= if search?
+        search_against(base_scope).includes(:user, :event)
+      else
+        base_scope.includes(:user, :event).order('users.first_name, users.last_name')
+      end
+    end
+
+    def search?
+      params[:query].present?
     end
 
     def base_scope

--- a/spec/features/admin/visit_requests/search_spec.rb
+++ b/spec/features/admin/visit_requests/search_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe 'Visit Requests SEARCH' do
+  let(:event) { create(:event) }
+  let!(:visit_request) { create(:visit_request, user: user_1, event: event) }
+  let!(:visit_request_2) { create(:visit_request, user: user_2, event: event) }
+  let(:user_1) { create(:user, first_name: 'Den', last_name: 'Med') }
+  let(:user_2) { create(:user, first_name: 'Ivan', last_name: 'Chai') }
+
+  before do
+    assume_admin_logged_in(supervisor: true)
+    visit "/admin/events/#{event.slug}/visit_requests"
+  end
+
+
+  it 'finds visit request by first name' do
+    fill_in 'query', with: user_1.first_name
+    click_on I18n.t('words.search')
+
+    expect(page).to have_content user_1.full_name
+    expect(page).not_to have_content user_2.full_name
+  end
+
+  it 'finds visit request by last name' do
+    fill_in 'query', with: user_2.last_name
+    click_on I18n.t('words.search')
+
+    expect(page).to have_content user_2.full_name
+    expect(page).not_to have_content user_1.full_name
+  end
+end


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/723)

### Description

Search by name does not work visit requests page.

### How to test instructions

- Visit http://localhost:3000/admin/events/pivorak-conference-717203c4-b08e-4dcd-9787-6c6bb2e6b63e/visit_requests
- Write `Andr` in search
- You can receive a Bullet `error`, but this is false alarm