### PR TITLE
Add places left info

### DIFF
--- a/app/controllers/admin/visit_requests_controller.rb
+++ b/app/controllers/admin/visit_requests_controller.rb
@@ -2,8 +2,10 @@
 
 module Admin
   class VisitRequestsController < ::Admin::BaseController
-    helper_method :visit_requests, :event, :visitors_ids, :confirmed_ids, :applied_ids,
-                  :pending_ids, :approved_ids
+    helper_method :visit_requests, :event, :visitors_ids,
+    :visitors_count,
+    :pending_count,
+    :places_left_count
 
     before_action :only_supervisor!
 
@@ -36,7 +38,19 @@ module Admin
     end
 
     def visitors_ids
-      @visitors_ids ||= User::EventAttendeesWithoutRefusedAndCanceled.call(event_id: event.id).ids
+      @visitors_ids ||= User::EventConfirmedAttendees.call(event_id: event.id).ids
+    end
+
+    def visitors_count
+      @visitors_count ||= visitors_ids.size
+    end
+
+    def pending_count
+      @pending_count ||= event.visit_requests.pending.count
+    end
+
+    def places_left_count
+      @places_left_count ||= event.limit_total - visitors_count
     end
   end
 end

--- a/app/finders/user/event_confirmed_attendees.rb
+++ b/app/finders/user/event_confirmed_attendees.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User
-  class EventAttendeesWithoutRefusedAndCanceled < ApplicationFinder
+  class EventConfirmedAttendees < ApplicationFinder
     def initialize(params = {})
       @event_id = params[:event_id]
     end
@@ -9,7 +9,7 @@ class User
     def call
       User.joins(:visit_requests)
           .where(visit_requests: { event_id: event_id })
-          .where(visit_requests: { id: VisitRequest.without_refused_and_canceled })
+          .where(visit_requests: { id: VisitRequest.confirmed_attendees })
     end
 
     private

--- a/app/models/visit_request.rb
+++ b/app/models/visit_request.rb
@@ -23,7 +23,7 @@ class VisitRequest < ApplicationRecord
   scope :final,           -> { where(status: [APPROVED, CONFIRMED]).main_list }
   scope :used,            -> { where(visited: true) }
   # TODO: why do we have 2 statuses?
-  scope :without_refused_and_canceled, -> { where.not(status: [CANCELED, REFUSED]) }
+  scope :confirmed_attendees, -> { where.not(status: [CANCELED, REFUSED, PENDING]) }
 
   def main_list!
     update(waiting_list: false)

--- a/app/views/admin/visit_requests/index.slim
+++ b/app/views/admin/visit_requests/index.slim
@@ -6,6 +6,12 @@
       = event.title
     = event_status_label(event)
 
+    h3 Refresh the page to update info below:
+
+    h3 Visitors: #{visitors_ids.size}
+    h3 Pending: #{pending_count}
+    h3 Places Left: #{places_left_count}
+
   .six.wide.column.bottom.aligned
     = render 'admin/shared/search_bar', path: admin_event_visit_requests_path
 


### PR DESCRIPTION
Resolves [github issue](https://github.com/pivorakmeetup/pivorak-web-app/issues/x)

### Description

Add info about:
- confirmed visitors
- pending visitors 
- how many places left for the event

### How to test instructions

- cap production postgres:replicate
- Visit http://localhost:3000/admin/events/pivorak-40-back-to-school-edition/visit_requests

### Screenshot

<img width="1280" alt="Screen Shot 2019-08-27 at 11 01 48 AM" src="https://user-images.githubusercontent.com/5591973/63752694-637b2d80-c8ba-11e9-8564-c75820adfe2c.png">