### PR TITLE
Refine `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,33 @@
 version: '3.7'
 
+x-app: &app
+  build:
+    context: .
+    dockerfile: ./Dockerfile
+    args:
+      RUBY_VERSION: '2.3.1'
+      BUNDLER_VERSION: '1.16.6'
+      NODE_MAJOR: '10'
+  image: pivorak-web-app:0.0.1
+  tmpfs:
+    - /tmp
+
+x-backend: &backend
+  <<: *app
+  stdin_open: true
+  tty: true
+  volumes:
+    - .:/app:cached
+    - rails_cache:/app/tmp/cache
+    - bundle:/bundle
+  environment:
+    - REDIS_URL=redis://redis:6379
+    - DATABASE_URL=postgres://postgres:postgres@postgres:5432
+  depends_on:
+    - postgres
+    - redis
+
 services:
-  app: &app
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-      args:
-        RUBY_VERSION: '2.3.1'
-        BUNDLER_VERSION: '1.16.6'
-        NODE_MAJOR: '10'
-    image: pivorak-web-app:0.0.1
-    tmpfs:
-      - /tmp
-
-  backend: &backend
-    <<: *app
-    stdin_open: true
-    tty: true
-    volumes:
-      - .:/app:cached
-      - rails_cache:/app/tmp/cache
-      - bundle:/bundle
-    environment:
-      - REDIS_URL=redis://redis:6379
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432
-    depends_on:
-      - postgres
-      - redis
-
   runner:
     <<: *backend
     command: /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,6 @@ services:
   runner:
     <<: *backend
     command: /bin/bash
-    ports:
-      - '3000:3000'
 
   rails:
     <<: *backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,6 @@ x-app: &app
   image: pivorak-web-app:0.0.1
   tmpfs:
     - /tmp
-
-x-backend: &backend
-  <<: *app
   stdin_open: true
   tty: true
   volumes:
@@ -29,17 +26,17 @@ x-backend: &backend
 
 services:
   runner:
-    <<: *backend
+    <<: *app
     command: /bin/bash
 
   rails:
-    <<: *backend
+    <<: *app
     command: bundle exec rails server -b 0.0.0.0
     ports:
       - '3000:3000'
 
   sidekiq:
-    <<: *backend
+    <<: *app
     command: bundle exec sidekiq -C config/sidekiq.yml
 
   postgres:


### PR DESCRIPTION
- Delete port mapping from `runnner` service
   Currently, there is no need to do so.

- Move `app` and `backend`  from services
  They aren't services, they are just common configs that is being used by services

- Merge `x-app` and `x-backend` into one - `x-app`
  `x-backend` configures an environment for the app as well, I don't see any reason keeping it separately.

Related to #https://github.com/pivorakmeetup/pivorak-web-app/pull/802