### PR TITLE
Remove duplicate pending migrations checks for testing

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,10 +24,6 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-# Checks for pending migration and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
-
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
I noticed there were 2 calls for this same check (3 if you count the one in [`components/courses/spec/rails_helper.rb`][3], but it doesn't seem you're using it): 1) in this [`rails_helper`][1] and 2) in the [`spec_helper`][2], so we can remove one of them.

Since `rails_helper` requires `spec_helper` in the beginning, it seems safe to remove the later one in `rails_helper`.

[1]: https://github.com/pivorakmeetup/pivorak-web-app/blob/d55f825fe7c5ac062fa51411c84b614519d026f6/spec/rails_helper.rb#L29
[2]: https://github.com/pivorakmeetup/pivorak-web-app/blob/d55f825fe7c5ac062fa51411c84b614519d026f6/spec/spec_helper.rb#L40
[3]: https://github.com/pivorakmeetup/pivorak-web-app/blob/d55f825fe7c5ac062fa51411c84b614519d026f6/components/courses/spec/rails_helper.rb#L19