### PR TITLE
add guide for speakers to the site menu

### DIFF
--- a/app/views/layouts/app/_header.slim
+++ b/app/views/layouts/app/_header.slim
@@ -23,6 +23,7 @@ header.pk-header class="#{header_classlist.compact.join(' ')}"
                 ul.pk-header__li-list
                   li.pk-header__li-list-item = about_link
                   li.pk-header__li-list-item = link_to 'code of conduct','/code-of-conduct'
+                  li.pk-header__li-list-item = link_to 'guide for speakers','/guide-for-speakers'
                   li.pk-header__li-list-item = link_to 'contact us','/contacts'
                   li.pk-header__li-list-item = link_to 'agreement','/user-agreement'
                   li.pk-header__li-list-item = link_to 'bug?', 'https://github.com/pivorakmeetup/pivorak-web-app/issues/new?labels=bug'


### PR DESCRIPTION
Issue: https://github.com/pivorakmeetup/pivorak-web-app/issues/827
Adding [guide for speakers](https://pivorak.com/guide-for-speakers) to the menu 