### PR TITLE
Замінити віджет на платіжну кнопку

### DIFF
--- a/app/assets/javascripts/app/donate_form.js
+++ b/app/assets/javascripts/app/donate_form.js
@@ -13,10 +13,6 @@
 
     if(agreeToTermsCheckbox) {
       agreeToTermsCheckbox.addEventListener('change', toggleBtns);
-      paymentBtn.addEventListener('click', function (event) {
-        event.preventDefault()
-        runWayforpayWidget()
-      });
     }
 
     var toggleElement = function(element) {
@@ -24,10 +20,7 @@
     }
   }
 
-  function runWayforpayWidget() {var wayforpay = new Wayforpay(); wayforpay.invoice('https://secure.wayforpay.com/button/b644556e003e4');}
-
   window.listenDonateTermsOfUse = listenDonateTermsOfUse;
-  window.runWayforpayWidget = runWayforpayWidget;
 
   $('.pk-donate-form').removeClass('pk-no-display')
 })();

--- a/app/views/donate/_btn.slim
+++ b/app/views/donate/_btn.slim
@@ -1,5 +1,0 @@
-- onclick ||= ''
-- hidden_class ||= ''
-- type ||= ''
-button class="#{js_class} #{hidden_class} ui primary submit button pk-btn pk-btn--medium" type="#{type}"
-  = t('pages.donate.submit_btn', locale: locale)

--- a/app/views/donate/show.html.slim
+++ b/app/views/donate/show.html.slim
@@ -11,5 +11,8 @@
       = f.input :agree_to_terms_of_use, label: t('pages.donate.by_pressing_btn_html', locale: locale), as: :boolean, required: true, error: false, input_html: {class: 'js-donate-form-agree'}
     .form-actions
       .mtl
-        = render 'btn', js_class: 'js-donate-form-payment-btn', onclick: 'runWayforpayWidget();', hidden_class: 'pk-no-display'
-        = render 'btn', js_class: 'js-donate-form-validation-btn', type: 'submit'
+        - style_css_class = 'ui primary submit button pk-btn pk-btn--medium'
+        / button for actual payment, hidden before you accept terms of use
+        = link_to t('pages.donate.submit_btn', locale: locale), 'https://secure.wayforpay.com/button/b644556e003e4', target: '_blank', class: ['js-donate-form-payment-btn', 'pk-no-display', style_css_class]
+        / accepts terms of use button
+        = button_tag t('pages.donate.submit_btn', locale: locale), class: ['js-donate-form-validation-btn', style_css_class]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,6 @@ Rails.application.routes.draw do
 
   resource :donate, only: %i[show create], controller: :donate do
     post :webhook, to: 'donate/webhook#create', on: :collection
-    # post :after_success, to: redirect('/thank-you-for-donating')
-    # post :after_failure, to: redirect('/donate-failed')
   end
   resources :speakers,  only: %i[index]
   resources :search,    only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
   resource :donate, only: %i[show create], controller: :donate do
     post :webhook, to: 'donate/webhook#create', on: :collection
+    post :after_success, to: redirect('/thank-you-for-donating')
+    post :after_failure, to: redirect('/donate-failed')
   end
   resources :speakers,  only: %i[index]
   resources :search,    only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,8 @@ Rails.application.routes.draw do
 
   resource :donate, only: %i[show create], controller: :donate do
     post :webhook, to: 'donate/webhook#create', on: :collection
-    post :after_success, to: redirect('/thank-you-for-donating')
-    post :after_failure, to: redirect('/donate-failed')
+    # post :after_success, to: redirect('/thank-you-for-donating')
+    # post :after_failure, to: redirect('/donate-failed')
   end
   resources :speakers,  only: %i[index]
   resources :search,    only: %i[index]

--- a/docs/wayforpay.md
+++ b/docs/wayforpay.md
@@ -1,0 +1,25 @@
+### Donation
+
+Ми використовуємо платіжну кнопку [WayForPay](https://wayforpay.com/uk) на сторінці https://pivorak.com/donate.
+
+Техпідтримка працює добре через Telegram, рекомендую.
+
+### Корисні посилання
+
+- [Налаштування магазину тут](https://m.wayforpay.com/uk/mportal/payed-block-configure/notice-update?id=50029)
+
+### Webhoook / Slack повідомлення
+
+Після оплати ми приймаємо webhook і постимо Slack повідомлення.
+
+#### Як працюють перенаправлення після оплати?
+
+у [Налаштуваннях магазину](https://m.wayforpay.com/uk/mportal/payed-block-configure/notice-update?id=50029) будуть здійснені перенаправлення на вказані URL-и: approvedUrl, declinedUrl, returnUrl.
+
+### Відомі проблеми
+
+- Apple Pay забороняє показ кнопки оплати в iframe (віджеті), можливий тільки перехід за прямим посиланням.
+
+### Ідеї:
+- зробити повідомлення неанонімними
+- додати можливість вказати повідомлення яке буде опубліковане в Slack

--- a/docs/wayforpay.md
+++ b/docs/wayforpay.md
@@ -6,7 +6,8 @@
 
 ### Корисні посилання
 
-- [Налаштування магазину тут](https://m.wayforpay.com/uk/mportal/payed-block-configure/notice-update?id=50029)
+- [Платіжна кнопка](https://m.wayforpay.com/uk/mportal/payments/button)
+- [Налаштування магазину](https://m.wayforpay.com/uk/mportal/payed-block-configure/notice-update?id=50029)
 
 ### Webhoook / Slack повідомлення
 


### PR DESCRIPTION
Resolve https://github.com/pivorakmeetup/pivorak-web-app/issues/895

### Description

**Чому?**: віджет не дозволяє зробити редіректи після оплати. віджет замінений на платіжну кнопку яку взяв з https://m.wayforpay.com/uk/mportal/payments/button

Раніше був віджет,  зараз відкриватиметься нова вкладка, але це дозволить перенаправляти користувача на pivorak сторінку [після успішної](https://pivorak.com/thank-you-for-donating) чи неуспішної оплати.

Також змінені [налаштування на сторінці wayforpay](https://m.wayforpay.com/uk/mportal/payed-block-configure/notice-update?id=50029)

### How to test instructions

- задонатити грошики
