### PR TITLE
#928 Added a link to privacy policy from the main menu

### DIFF
--- a/app/views/layouts/app/_header.slim
+++ b/app/views/layouts/app/_header.slim
@@ -26,6 +26,7 @@ header.pk-header class="#{header_classlist.compact.join(' ')}"
                   li.pk-header__li-list-item = link_to 'guide for speakers','/guide-for-speakers'
                   li.pk-header__li-list-item = link_to 'contact us','/contacts'
                   li.pk-header__li-list-item = link_to 'agreement','/user-agreement'
+                  li.pk-header__li-list-item = link_to 'privacy policy','/privacy'
                   li.pk-header__li-list-item = link_to 'bug?', 'https://github.com/pivorakmeetup/pivorak-web-app/issues/new?labels=bug'
 
               li.pk-list__unit.pk-header__li-list-wr

--- a/db/seed/pages/privacy_policy.md
+++ b/db/seed/pages/privacy_policy.md
@@ -1,0 +1,71 @@
+Effective Date: **June 22nd, 2020**
+
+We at #pivorak care about your privacy and the personal information you share with us. Please read the following to learn how we collect, protect, and use your personal information. By using or accessing the Services in any manner, you acknowledge that you accept the practices and policies outlined in this Privacy Policy, and you hereby consent that we will collect, use, and share your information in the following ways.
+
+## What does this Privacy Policy cover?
+This Privacy Policy covers our treatment of personally identifiable information ("Personal Information") that we gather when you are accessing or using our Services, but not to the practices of companies we don’t own or control, or people that we don’t manage. We gather various types of Personal Information from our users, as explained in more detail below, and we use this Personal Information internally in connection with our Services, including to personalize, provide, and improve our services, to allow you to set up a user account and profile and to register for #pivorak events, to contact you about #pivorak events and activities, to fulfill your requests for certain products and services, and to analyze how you use the Services. In certain cases, we may also share some Personal Information with third parties, but only as described below.
+
+## Will #pivorak ever change this Privacy Policy?
+We are constantly trying to improve our Services, so we may need to change this Privacy Policy from time to time as well, but we will alert you to changes by updating the services on the website, placing a notice on the website, by sending you an email, and/or by some other means. Please note that if you’ve opted not to receive legal notice emails from us (or you haven’t provided us with your email address), those legal notices will still govern your use of the Services, and you are still responsible for reading and understanding them. If you use the Services after any changes to the Privacy Policy have been posted, that means you agree to all of the changes. Use of information we collect now is subject to the Privacy Policy in effect at the time such information is used or collected.
+
+## What Information does #pivorak Collect?
+
+**Information you provide to us:**
+We receive and store any information you knowingly provide to us. For example, through the account registration process we may collect Personal Information such as your name, email address, and/or third-party account credentials (for example, your log-in credentials for Facebook, Github, or Twitter). If you provide your third-party account credentials to us or otherwise sign in to the Services through a third party site or service, you understand some content and/or information in those accounts (“Third Party Account Information”) may be transmitted into your account with us, and that Third Party Account Information transmitted to our Services is covered by this Privacy Policy; for example, we import your first and last name and your email from Facebook/Github/Twitter to use as your contact information.
+
+We store information about your attendance of #pivorak events. This includes when you register for an event, click a confirmation link inside our email, or allow us to scan your electronic ticket at the event.
+
+We may communicate with you if you’ve provided us the means to do so. For example, if you’ve given us your email address, we may send you information about #pivorak events or email you about your use of the Services. If you do not want to receive communications from us, please email us at pivorak.me@gmail.com.
+
+**Information collected automatically**
+Whenever you interact with our Services, we automatically receive and record information on our server logs from your browser or device, which may include your IP address, geolocation data, device identification, “cookie” information, the type of browser and/or device you’re using to access our Services, and the page or feature you requested. “Cookies” are identifiers we transfer to your browser or device that allow us to recognize your browser or device and tell us how and when pages and features in our Services are visited and by how many people. You may be able to change the preferences on your browser or device to prevent or limit your device’s acceptance of cookies, but this may prevent you from taking advantage of some of our features. 
+
+We do not store this data in your account alongside your Personal Information. We may, however, use it to improve the Services – for example, this data can tell us how often users use a particular feature of the Services, and we can use that knowledge to make the Services interesting to as many users as possible.
+
+## How does #pivorak use my Personal Information?
+ #pivorak may use Personal Information it receives for the following purposes:
+
+* To provide and maintain our Services, including to monitor the usage of our Services.
+* To manage your account: to manage your registration as a user of the Services. The Personal Information you provide can give you access to different functionalities of the Services that are available to you as a registered user.
+* To contact you by email or other means you have provided to us about upcoming #pivorak events or activities, to deliver electronic tickets and reminders for the events you registered for, to inform you about changes to Services.
+* To provide you with news, special offers and general information about other goods, services and events which we offer.
+* To manage your requests to us.
+
+## Will #pivorak share any of the Personal Information it receives?
+We may share your Personal Information with third parties as described in this section:
+
+**Analytics:** We may use third party analytics services, such as Mixpanel or Google Analytics, to grow our business, to improve and develop our Services, to monitor and analyze use of our Services, to aid our technical administration, to increase the functionality and user-friendliness of our Services, and to verify that users have the authorization needed for us to process their requests. These analytics services may collect and retain some information about you. For instance, Google Analytics collects the IP address assigned to you on the date you use the Services, but not your name or other personally identifying information. We do not combine the information generated through the use of Google Analytics with your Personal Information. Although Google Analytics plants a persistent cookie on your web browser to identify you as a unique user the next time you use the Services, the cookie cannot be used by anyone but Google. Google’s ability to use and share information collected by Google Analytics about your use of the Services is restricted by the Google Analytics Terms of Use and the Google Privacy Policy. You may find additional information about Google Analytics at www.google.com/policies/privacy/partners/. Finally, you can opt out of Google Analytics by visiting https://tools.google.com/dlpage/gaoptout/.
+
+**Agents:** We employ other companies and people to perform tasks on our behalf and need to share your information with them to provide products or services to you. Unless we tell you differently, our agents do not have any right to use the Personal Information we share with them beyond what is necessary to assist us.
+
+**Other Users:** Certain user profile information, including your name and any image content that you have uploaded to the Services, may be displayed to other users to facilitate user interaction within the Services or address your request for our services. 
+
+**Protection of #pivorak and Others.** We reserve the right to access, read, preserve, and disclose any information that we believe is necessary to comply with law or court order; enforce or apply our Terms of Use and other agreements; or protect the rights, property, or safety of #pivorak, our employees, our users, or others.
+
+**Information that’s been de-identified.** We may de-identify your Personal Information so that you are not identified as an individual, and provide that information to our partners and sponsors. We may also provide aggregate usage information to our partners, who may use such information to understand how often and in what ways people use our Services, so that they can, for example, decide to support the community financially. However, except for the categories of sharing we described above, we never disclose aggregate usage or de-identified information to a partner (or allow a partner to collect such information) in a manner that would identify you as an individual person.
+
+## Is Personal Information about me secure?
+We have implemented controls to protect your personal data against unauthorized processing and against accidental loss, damage or destruction. You are responsible for choosing a secure password when we ask you to set up a password to access parts of our site. You should keep this password confidential. You should not share your password with anyone else, including anyone who works for us.
+
+If you access your account via a third party authorization service, you may have additional or different sign-on protections via that third party site or service. You must prevent unauthorized access to your account and Personal Information by selecting and protecting your password and/or other sign-on mechanism appropriately and limiting access to your computer or device and browser by signing off after you have finished accessing your account.
+
+We endeavor to protect the privacy of your account and other Personal Information we hold in our records, but unfortunately, we cannot guarantee complete security. Unauthorized entry or use, hardware or software failure, and other factors, may compromise the security of user information at any time.
+
+## What Personal Information can I access?
+Through your profile page, you may access or edit the following information you’ve provided to us:
+
+* first and last name
+* email
+
+The information you can view, update, or delete may change as our Services change. If you have any questions about viewing or updating information we have on file about you, please contact us at pivorak.me@gmail.com.
+
+## What choices do I have?
+We strive to request the minimum amount of Personal Information from you required to provide you with our Services. You can always opt not to disclose information to us, but keep in mind some information may be needed to register with us or to attend our events.
+
+## Links to other websites
+Our Website may contain links to other websites that are not operated by us. If you click on a third party link, you will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you visit.
+
+We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.
+
+## What if I have questions about this policy?
+If you have any questions or concerns regarding our privacy policies, please send us a detailed message to pivorak.me@gmail.com, and we will try to resolve your concerns.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,8 +42,12 @@ puts Venue.where(name: 'iHUB', description: 'http://ihub.world/ua/lviv-ua/',
 #=== Pages ====================================================================
 puts Page.where(title: 'About',    body: '...', url: 'about').first_or_create!
 puts Page.where(title: 'Contacts', body: '...', url: 'contacts').first_or_create!
-puts Page.where(url: 'public-agreement').first_or_create!(title: 'Public Agreement',
-                                                          body: File.read('db/seed/pages/public_agreement.md'))
+
+public_agreement = File.join('db', 'seed', 'pages', 'public_agreement.md')
+puts Page.where(url: 'public-agreement').first_or_create!(title: 'Public Agreement', body: File.read(public_agreement))
+
+privacy_policy = File.join('db', 'seed', 'pages', 'privacy_policy.md')
+puts Page.where(url: 'privacy').first_or_create!(title: 'Privacy Policy', body: File.read(privacy_policy))
 
 #=== Email Template ===========================================================
 puts Rake::Task['email_templates:seed'].execute


### PR DESCRIPTION
Resolves [#928](https://github.com/pivorakmeetup/pivorak-web-app/issues/928)

### Description

Added a main menu link to our privacy policy. This is required to reenable our Facebook Oath integration.

### How to test instructions

**Note:** To test locally, run the following to create a privacy policy page:

```
bundle exec rake db:seed
```
There's no need to run it in production - the page already exists.

**Before:**

<img width="627" alt="Screen Shot 2020-07-03 at 6 59 20 PM" src="https://user-images.githubusercontent.com/8246202/86485414-509a7a80-bd61-11ea-8d8d-e7935a46b4d8.png">

**After:**

<img width="646" alt="Screen_Shot_2020-07-03_at_6_59_08_PM" src="https://user-images.githubusercontent.com/8246202/86485446-614af080-bd61-11ea-827b-769cfffcd6e6.png">