### PR TITLE
#930 Fixed a typo on the home page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   # TODO: [1.1] Remove
-  helper_method :event, :talks, :visit_request, :attendees, :upcoming_date
+  helper_method :event, :talks, :visit_request, :attendees, :planned_event, :upcoming_date
 
   def index
     if event

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   # TODO: [1.1] Remove
-  helper_method :event, :talks, :visit_request, :attendees, :planned_event, :upcoming_date
+  helper_method :event, :talks, :visit_request, :attendees, :coming_soon_message
 
   def index
     if event
@@ -13,6 +13,12 @@ class HomeController < ApplicationController
   end
 
   private
+
+  def coming_soon_message
+    return t('coming_soon.getting_ready') if planned_event.blank?
+
+    t('coming_soon.next_event', upcoming_date: upcoming_date)
+  end
 
   def upcoming_date
     return 'soon' unless planned_event.present?

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -6,7 +6,10 @@
         | #pivorak
   .pk-home-layout__content-wrapper
     .pk-home-layout__content
-      p = t('coming_soon.next_event', upcoming_date: upcoming_date)
+      - if planned_event.present?
+        p = t('coming_soon.next_event', upcoming_date: upcoming_date)
+      - else
+        p = t('coming_soon.getting_ready')
       p = t('coming_soon.cfp_is_open')
       = become_a_speaker_link(class: 'btn pk-btn pk-btn--biggest pk-btn--green-bg')
 

--- a/app/views/home/index.slim
+++ b/app/views/home/index.slim
@@ -6,10 +6,7 @@
         | #pivorak
   .pk-home-layout__content-wrapper
     .pk-home-layout__content
-      - if planned_event.present?
-        p = t('coming_soon.next_event', upcoming_date: upcoming_date)
-      - else
-        p = t('coming_soon.getting_ready')
+      p = coming_soon_message
       p = t('coming_soon.cfp_is_open')
       = become_a_speaker_link(class: 'btn pk-btn pk-btn--biggest pk-btn--green-bg')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
       date_month_year_and_date_time: '%e %b %Y %H:%M:%p'
   coming_soon:
     next_event: Next event will happen on %{upcoming_date}.
+    getting_ready: We are getting ready for our next event.
     cfp_is_open: Call for speakers is open!
     follow_us: follow us to keep in touch
 

--- a/spec/features/home/coming_soon_page_features_spec.rb
+++ b/spec/features/home/coming_soon_page_features_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Coming Soon page' do
     it 'renders coming soon page with unknown date' do
       visit root_path
 
-      expect(page).to have_content(I18n.t('coming_soon.next_event', upcoming_date: 'soon'))
+      expect(page).to have_content(I18n.t('coming_soon.getting_ready'))
       expect(page).to have_content(I18n.t('coming_soon.cfp_is_open'))
     end
   end


### PR DESCRIPTION
Resolves [#930](https://github.com/pivorakmeetup/pivorak-web-app/issues/930)

### Description

On the home page, changed "Next event will happen on soon." => "We are getting ready for our next event."

### How to test instructions

Make sure that:

- there are no planned events in the DB (`Event.planned.count == 0`)
- there isn't an upcoming event (`Event.upcoming == nil`)

Visit the home page (`/`) and make sure the text says "We are getting ready for our next event." instead of "Next event will happen on soon."
